### PR TITLE
Add an ability to set and reset Toastify options globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ There are several options that can be passed in as a second parameter, like the 
 showError('This is an error shown without a timeout', { timeout: -1 })
 ```
 
+You could set option for the whole project globally:
+
+```
+setGlobalToastOptions({ selector: 'vue-app',  timeout: -1 })
+```
+
 A full list of available options can be found in the [documentation](https://nextcloud.github.io/nextcloud-dialogs/).
 
 ## Releasing a new version

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,6 +2,6 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: lib/toast.ts:223
+#: lib/toast.ts:243
 msgid "Undo"
 msgstr ""

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
 export { FilePicker, FilePickerType, FilePickerBuilder, getFilePickerBuilder } from './filepicker'
 export { TOAST_UNDO_TIMEOUT, TOAST_DEFAULT_TIMEOUT, TOAST_PERMANENT_TIMEOUT } from './toast'
 export { TOAST_ARIA_LIVE_OFF, TOAST_ARIA_LIVE_POLITE, TOAST_ARIA_LIVE_ASSERTIVE } from './toast'
-export { showMessage, showSuccess, showWarning, showInfo, showError, showUndo } from './toast'
+export { showMessage, showSuccess, showWarning, showInfo, showError, showUndo, setGlobalToastOptions, resetGlobalToastOptions } from './toast'

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -94,10 +94,31 @@ export interface ToastOptions {
 	ariaLive?: ToastAriaLive
 }
 
+const globalToastOptions: ToastOptions = {}
+
+/**
+ * Set default options for toast messages globally
+ *
+ * @param options
+ */
+export function setGlobalToastOptions(options: ToastOptions): void {
+	Object.assign(globalToastOptions, options)
+}
+
+/**
+ * Reset default options for toast messages globally
+ *
+ */
+export function resetGlobalToastOptions(): void {
+	Object.keys(globalToastOptions).forEach(key => {
+		delete globalToastOptions[key];
+	});
+}
+
 /**
  * Show a toast message
  *
- * @param text Message to be shown in the toast, any HTML is removed by default
+ * @param data Message to be shown in the toast, any HTML is removed by default
  * @param options
  */
 export function showMessage(data: string|Node, options?: ToastOptions): Toast {
@@ -110,10 +131,9 @@ export function showMessage(data: string|Node, options?: ToastOptions): Toast {
 		onRemove: () => { },
 		onClick: undefined,
 		close: true
-	}, options)
+	}, globalToastOptions, options)
 
 	if (typeof data === 'string' && !options.isHTML) {
-		// fime mae sure that text is extracted
 		const element = document.createElement('div')
 		element.innerHTML = data
 		data = element.innerText


### PR DESCRIPTION
### ☑️ Resolves

* Add `setGlobalToastOptions(options: ToastOptions)` function
* Add `resetGlobalToastOptions()` function
* Update README.md
* Fix typos, remove redundant comments
* Close #380 

___

### 🚧 Tasks

- [ ] Code review
- [x] ⛑️ Tested in sandbox and Talk
- [ ] 📘 API or User documentation - should be updated?
