### PR TITLE
fix(FilePicker): Adjust color of placeholder skeletons

### DIFF
--- a/lib/components/FilePicker/LoadingTableRow.vue
+++ b/lib/components/FilePicker/LoadingTableRow.vue
@@ -40,7 +40,7 @@
 		display: inline-block;
 		height: 24px;
 
-		background: linear-gradient(to right,var(--color-background-darker),var(--color-main-text),var(--color-background-darker));
+		background: linear-gradient(to right,var(--color-background-darker),var(--color-text-maxcontrast),var(--color-background-darker));
 		background-size: 600px 100%;
 		border-radius: var(--border-radius);
 		animation: gradient 12s ease infinite;


### PR DESCRIPTION
Adjust color as suggested by @jancborchardt (I can somehow not request a review from you using GH, but feedback is very welcome :wink: ).

I changed the background to
```css
background: linear-gradient(to right,var(--color-background-darker),var(--color-text-maxcontrast),var(--color-background-darker));
background-size: 600px 100%;
border-radius: var(--border-radius);
animation: gradient 12s ease infinite;
```

### Screenshots

before | after
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/98488a82-4a77-4700-877a-17253aa27a8a) | ![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/1d4c3591-50f3-4362-8551-4d5aa3aa37a0)
