### PR TITLE
FilePickerBuilder: Allow to add custom buttons and use shipped picker

### DIFF
--- a/lib/filepicker.ts
+++ b/lib/filepicker.ts
@@ -1,131 +1,170 @@
 /// <reference types="@nextcloud/typings" />
 
-declare const OC: Nextcloud.v25.OC | Nextcloud.v26.OC | Nextcloud.v27.OC;
+declare const OC: Nextcloud.v25.OC | Nextcloud.v26.OC | Nextcloud.v27.OC
 
 export enum FilePickerType {
-    Choose = 1,
-    Move = 2,
-    Copy = 3,
-    CopyMove = 4,
-    Custom = 5,
+	Choose = 1,
+	Move = 2,
+	Copy = 3,
+	CopyMove = 4,
+	Custom = 5,
+}
+
+export interface FilePickerButton {
+	text: string
+	type?: 'primary' | 'secondary'
+	/** Passed on the callback as second argument */
+	id: number
 }
 
 export class FilePicker {
-    private title: string
-    private multiSelect: boolean
-    private mimeTypeFiler: string[]
-    private modal: boolean
-    private type: FilePickerType
-    private directoriesAllowed: boolean
-    private path?: string
-    private filter?: Nextcloud.v24.FilePickerFilter
 
-    public constructor(title: string,
-        multiSelect: boolean,
-        mimeTypeFilter: string[],
-        modal: boolean,
-        type: FilePickerType,
-        directoriesAllowed: boolean,
-        path?: string,
-        filter?: Nextcloud.v24.FilePickerFilter) {
-        this.title = title
-        this.multiSelect = multiSelect
-        this.mimeTypeFiler = mimeTypeFilter
-        this.modal = modal
-        this.type = type
-        this.directoriesAllowed = directoriesAllowed
-        this.path = path
-        this.filter = filter
-    }
+	private title: string
+	private multiSelect: boolean
+	private mimeTypeFiler: string[]
+	private modal: boolean
+	private type: FilePickerType
+	private directoriesAllowed: boolean
+	private buttons?: FilePickerButton[]
+	private path?: string
+	private filter?: Nextcloud.v24.FilePickerFilter
 
-    public pick(): Promise<string> {
-        return new Promise((res, rej) => {
-            OC.dialogs.filepicker(
-                this.title,
-                res,
-                this.multiSelect,
-                this.mimeTypeFiler,
-                this.modal,
-                this.type,
-                this.path,
-                {
-                    allowDirectoryChooser: this.directoriesAllowed,
-                    filter: this.filter,
-                },
-            )
-        })
-    }
+	public constructor(title: string,
+		multiSelect: boolean,
+		mimeTypeFilter: string[],
+		modal: boolean,
+		type: FilePickerType,
+		directoriesAllowed: boolean,
+		path?: string,
+		filter?: Nextcloud.v24.FilePickerFilter,
+		buttons?: FilePickerButton[]) {
+		this.title = title
+		this.multiSelect = multiSelect
+		this.mimeTypeFiler = mimeTypeFilter
+		this.modal = modal
+		this.type = type
+		this.directoriesAllowed = directoriesAllowed
+		this.path = path
+		this.filter = filter
+		this.buttons = buttons
+	}
+
+	public pick(): Promise<[string|string[], FilePickerType]> {
+		return new Promise((resolve) => {
+			const buttons = this.buttons?.map(button => ({
+				defaultButton: button.type === 'primary',
+				label: button.text,
+				type: button.id,
+			}))
+
+			OC.dialogs.filepicker(
+				this.title,
+				(path: string | string[], type: FilePickerType) => resolve([path, type]),
+				this.multiSelect,
+				this.mimeTypeFiler,
+				this.modal,
+				this.type,
+				this.path,
+				{
+					allowDirectoryChooser: this.directoriesAllowed,
+					filter: this.filter,
+					buttons,
+				},
+			)
+		})
+	}
+
 }
 
 export class FilePickerBuilder {
-    private title: string
-    private multiSelect: boolean = false
-    private mimeTypeFiler: string[] = []
-    private modal: boolean = true
-    private type: FilePickerType = FilePickerType.Choose
-    private directoriesAllowed: boolean = false
-    private path?: string
-    private filter?: Nextcloud.v24.FilePickerFilter
 
-    public constructor(title: string) {
-        this.title = title
-    }
+	private title: string
+	private multiSelect = false
+	private mimeTypeFiler: string[] = []
+	private modal = true
+	private type: FilePickerType = FilePickerType.Choose
+	private directoriesAllowed = false
+	private path?: string
+	private filter?: Nextcloud.v24.FilePickerFilter
+	private buttons: FilePickerButton[] = []
 
-    public setMultiSelect(ms: boolean): FilePickerBuilder {
-        this.multiSelect = ms
-        return this
-    }
+	public constructor(title: string) {
+		this.title = title
+	}
 
-    public addMimeTypeFilter(filter: string): FilePickerBuilder {
-        this.mimeTypeFiler.push(filter)
-        return this
-    }
+	public setMultiSelect(ms: boolean): FilePickerBuilder {
+		this.multiSelect = ms
+		return this
+	}
 
-    public setMimeTypeFilter(filter: string[]): FilePickerBuilder {
-        this.mimeTypeFiler = filter
-        return this
-    }
+	public addMimeTypeFilter(filter: string): FilePickerBuilder {
+		this.mimeTypeFiler.push(filter)
+		return this
+	}
 
-    public setModal(modal: boolean): FilePickerBuilder {
-        this.modal = modal
-        return this
-    }
+	public setMimeTypeFilter(filter: string[]): FilePickerBuilder {
+		this.mimeTypeFiler = filter
+		return this
+	}
 
-    public setType(type: FilePickerType): FilePickerBuilder {
-        this.type = type
-        return this
-    }
+	public addButton(button: FilePickerButton): FilePickerBuilder {
+		this.buttons.push(button)
+		return this
+	}
 
-    public allowDirectories(allow: boolean = true): FilePickerBuilder {
-        this.directoriesAllowed = allow
-        return this
-    }
+	/**
+	 * @param modal no function
+	 * @deprecated Does not have any effect as the dialog is always modal
+	 */
+	public setModal(modal: boolean): FilePickerBuilder {
+		this.modal = modal
+		return this
+	}
 
-    public startAt(path: string): FilePickerBuilder {
-        this.path = path
-        return this
-    }
+	public setType(type: FilePickerType): FilePickerBuilder {
+		this.type = type
+		return this
+	}
 
-    public setFilter(filter: Nextcloud.v24.FilePickerFilter): FilePickerBuilder {
-        this.filter = filter
-        return this
-    }
+	public allowDirectories(allow = true): FilePickerBuilder {
+		this.directoriesAllowed = allow
+		return this
+	}
 
-    public build(): FilePicker {
-        return new FilePicker(
-            this.title,
-            this.multiSelect,
-            this.mimeTypeFiler,
-            this.modal,
-            this.type,
-            this.directoriesAllowed,
-            this.path,
-            this.filter,
-        )
-    }
+	public startAt(path: string): FilePickerBuilder {
+		this.path = path
+		return this
+	}
+
+	public setFilter(filter: Nextcloud.v24.FilePickerFilter): FilePickerBuilder {
+		this.filter = filter
+		return this
+	}
+
+	public build(): FilePicker {
+		if (this.buttons && this.type !== FilePickerType.Custom) {
+			console.error('FilePickerBuilder: When adding custom buttons the `type` must be set to `FilePickerType.Custom`.')
+		}
+
+		return new FilePicker(
+			this.title,
+			this.multiSelect,
+			this.mimeTypeFiler,
+			this.modal,
+			this.type,
+			this.directoriesAllowed,
+			this.path,
+			this.filter,
+			this.buttons,
+		)
+	}
 
 }
 
+/**
+ *
+ * @param title Title of the file picker
+ */
 export function getFilePickerBuilder(title: string): FilePickerBuilder {
-    return new FilePickerBuilder(title)
+	return new FilePickerBuilder(title)
 }

--- a/lib/filepicker.ts
+++ b/lib/filepicker.ts
@@ -1,7 +1,5 @@
 /// <reference types="@nextcloud/typings" />
 
-declare const OC: Nextcloud.v25.OC | Nextcloud.v26.OC | Nextcloud.v27.OC
-
 export enum FilePickerType {
 	Choose = 1,
 	Move = 2,
@@ -49,7 +47,10 @@ export class FilePicker {
 		this.buttons = buttons
 	}
 
-	public pick(): Promise<[string|string[], FilePickerType]> {
+	public async pick(): Promise<[string|string[], FilePickerType]> {
+		// Async import for module splitting (treeshaking)
+		const filepicker = (await import('./legacy')).filepicker
+
 		return new Promise((resolve) => {
 			const buttons = this.buttons?.map(button => ({
 				defaultButton: button.type === 'primary',
@@ -57,7 +58,7 @@ export class FilePicker {
 				type: button.id,
 			}))
 
-			OC.dialogs.filepicker(
+			filepicker(
 				this.title,
 				(path: string | string[], type: FilePickerType) => resolve([path, type]),
 				this.multiSelect,


### PR DESCRIPTION
* Resolves #719 

The file picker builder should support the custom buttons option. Also this changes the file picker builder to use the bundled file picker instead of the global one from the server.

(some linting fixes included (space to tab)).

Changes are kept simple so back porting to stable4 without being a breaking change should be simple.