### PR TITLE
FilePicker: Ensure only the file table is scrolled

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -26,11 +26,11 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:213
+#: lib/components/FilePicker/FilePicker.vue:214
 msgid "Could not create the new folder"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:136
+#: lib/components/FilePicker/FilePicker.vue:137
 #: lib/components/FilePicker/FilePickerNavigation.vue:65
 msgid "Favorites"
 msgstr ""
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:136
+#: lib/components/FilePicker/FilePicker.vue:137
 #: lib/components/FilePicker/FilePickerNavigation.vue:61
 msgid "Recent"
 msgstr ""

--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -182,6 +182,10 @@ function onChangeDirectory(dir: Node) {
 			table-layout: fixed;
 		}
 		th {
+			position: sticky;
+			top: 0;
+			background-color: var(--color-main-background);
+
 			&.row-checkbox {
 				width: 44px;
 			}

--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -112,6 +112,7 @@ const dialogProps = computed(() => ({
 	buttons: dialogButtons.value,
 	size: 'large',
 	navigationClasses: ['file-picker__navigation'],
+	contentClasses: ['file-picker__content'],
 }))
 
 /**
@@ -242,6 +243,16 @@ export default {
 
 	&__main {
 		width: 100%;
+		display: flex;
+		flex-direction: column;
+		// Auto fit height
+		min-height: 0;
+		flex: 1;
 	}
+}
+
+:deep(.file-picker__content) {
+	display: flex;
+	flex-direction: column;
 }
 </style>


### PR DESCRIPTION
This fixes an issue where the dialog content is scrolled instead of only the file table:

### before
https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/88a07e7c-d97d-43aa-b65f-1f767af1d9f1


### after
https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/0071e32e-29dc-4db2-9b61-3df04a9d0310

