### PR TITLE
fix(FilePicker): The table height should be max. 100%

### DIFF
--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -178,7 +178,7 @@ function onChangeDirectory(dir: Node) {
 
 		table {
 			width: 100%;
-			height: 100%;
+			max-height: 100%;
 			table-layout: fixed;
 		}
 		th {

--- a/lib/components/FilePicker/FilePickerBreadcrumbs.vue
+++ b/lib/components/FilePicker/FilePickerBreadcrumbs.vue
@@ -120,3 +120,12 @@ const pathElements = computed(() => props.path.split('/')
 	})),
 )
 </script>
+
+<style scoped lang="scss">
+file-picker {
+	&__breadcrumbs {
+		// ensure the breadcrumbs have a static height
+		flex-grow: 0;
+	}
+}
+</style>


### PR DESCRIPTION
If the height is set to 100% the rows are resized and look weird.

### Screenshots
before | after
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/5d1396eb-640d-4378-9c1c-8c5acf7bb744)|![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/12a99436-0d95-4fa1-a64c-a6a2aa066381)
