### PR TITLE
fix(FilePickerBuilder): Revert API change on `pick()`

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -18,11 +18,11 @@ msgstr ""
 msgid "All files"
 msgstr ""
 
-#: lib/filepicker.ts:178
+#: lib/filepicker.ts:182
 msgid "Choose"
 msgstr ""
 
-#: lib/filepicker.ts:166
+#: lib/filepicker.ts:170
 msgid "Copy"
 msgstr ""
 
@@ -43,8 +43,8 @@ msgstr ""
 msgid "Modified"
 msgstr ""
 
-#: lib/filepicker.ts:172
-#: lib/filepicker.ts:186
+#: lib/filepicker.ts:176
+#: lib/filepicker.ts:190
 msgid "Move"
 msgstr ""
 


### PR DESCRIPTION
Resolves #919 

* Return `string` is multiSelect is false, `string[]` otherwise
* Adjust Typescript interface to infer types correctly, e.g. return type of `pick(): string`

(todo: I still looking for good way to test the typescript interface)