### PR TITLE
fix(FilePicker): Fix properties of the `new` button in the breadcrumbs

### DIFF
--- a/lib/components/FilePicker/FilePickerBreadcrumbs.vue
+++ b/lib/components/FilePicker/FilePickerBreadcrumbs.vue
@@ -17,8 +17,8 @@
 		<template v-if="showMenu" #actions>
 			<NcActions :aria-label="t('Create directory')"
 				:force-menu="true"
-				:force-name="true"
-				:menu-name="t('New')"
+				:force-title="true"
+				:menu-title="t('New')"
 				type="secondary"
 				@close="newNodeName = ''">
 				<template #icon>


### PR DESCRIPTION
Stable 4 uses nextcloud-vue version 7.x which had slightly different property names

![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/f9002794-61c7-4f52-a927-07bb8c0e8583)

Part of #920 