### PR TITLE
Add empty content when there are no files

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -26,17 +26,25 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:210
+#: lib/components/FilePicker/FilePicker.vue:241
 msgid "Could not create the new folder"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:133
+#: lib/components/FilePicker/FilePicker.vue:151
 #: lib/components/FilePicker/FilePickerNavigation.vue:65
 msgid "Favorites"
 msgstr ""
 
 #: lib/components/FilePicker/FilePickerBreadcrumbs.vue:87
 msgid "File name cannot be empty."
+msgstr ""
+
+#: lib/components/FilePicker/FilePicker.vue:227
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+#: lib/components/FilePicker/FilePicker.vue:225
+msgid "Files and folders you recently modified will show up here."
 msgstr ""
 
 #: lib/components/FilePicker/FileList.vue:39
@@ -52,7 +60,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:133
+#: lib/components/FilePicker/FilePicker.vue:151
 #: lib/components/FilePicker/FilePickerNavigation.vue:61
 msgid "Recent"
 msgstr ""
@@ -67,4 +75,8 @@ msgstr ""
 
 #: lib/toast.ts:242
 msgid "Undo"
+msgstr ""
+
+#: lib/components/FilePicker/FilePicker.vue:223
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -15,7 +15,8 @@
 			</div>
 
 			<!-- File list -->
-			<FileList :allow-pick-directory="allowPickDirectory"
+			<FileList v-if="filteredFiles.length > 0"
+				:allow-pick-directory="allowPickDirectory"
 				:files="filteredFiles"
 				:multiselect="multiselect"
 				:loading="isLoading"
@@ -23,25 +24,42 @@
 				:selected-files.sync="selectedFiles"
 				:name="viewHeadline"
 				@update:path="currentView = 'files'" />
+			<NcEmptyContent v-else-if="filterString"
+				:name="t('No matching files')"
+				:description="t('No files matching your filter were found.')">
+				<template #icon>
+					<IconFile />
+				</template>
+			</NcEmptyContent>
+			<NcEmptyContent v-else
+				:name="t('No files in here')"
+				:description="noFilesDescription">
+				<template #icon>
+					<IconFile />
+				</template>
+			</NcEmptyContent>
 		</div>
 	</DialogBase>
 </template>
 
 <script setup lang="ts">
 import type { IFilePickerButton, IFilePickerFilter } from '../types'
-import { davRootPath, type Node } from '@nextcloud/files'
+import type { Node } from '@nextcloud/files'
 
+import IconFile from 'vue-material-design-icons/File.vue'
 import DialogBase from '../DialogBase.vue'
 import FileList from './FileList.vue'
 import FilePickerBreadcrumbs from './FilePickerBreadcrumbs.vue'
 import FilePickerNavigation from './FilePickerNavigation.vue'
 
-import { t } from '../../utils/l10n'
+import { davRootPath } from '@nextcloud/files'
+import { NcEmptyContent } from '@nextcloud/vue'
 import { join } from 'path'
 import { computed, onMounted, ref, toRef } from 'vue'
+import { showError } from '../../toast'
 import { useDAVFiles } from '../../usables/dav'
 import { useMimeFilter } from '../../usables/mime'
-import { showError } from '../../toast'
+import { t } from '../../utils/l10n'
 
 const props = withDefaults(defineProps<{
 	/** Buttons to be displayed */
@@ -195,6 +213,19 @@ const filteredFiles = computed(() => {
 		filtered = filtered.filter((f) => props.filterFn(f as Node))
 	}
 	return filtered
+})
+
+/**
+ * If no files are found in the current view this message will be shown in the EmptyContent
+ */
+const noFilesDescription = computed(() => {
+	if (currentView.value === 'files') {
+		return t('Upload some content or sync with your devices!')
+	} else if (currentView.value === 'recent') {
+		return t('Files and folders you recently modified will show up here.')
+	} else {
+		return t('Files and folders you mark as favorite will show up here.')
+	}
 })
 
 /**


### PR DESCRIPTION
* Part of #920 

If there are no files in the current view or no matching filter, show the empty content component instead of the file list.

![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/dd27d72f-2f59-475f-b1d5-b8b0bbccf462)