### PR TITLE
[stable4] fix: The file list should be showed when files are loading

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -30,11 +30,11 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:241
+#: lib/components/FilePicker/FilePicker.vue:242
 msgid "Could not create the new folder"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:151
+#: lib/components/FilePicker/FilePicker.vue:152
 #: lib/components/FilePicker/FilePickerNavigation.vue:65
 msgid "Favorites"
 msgstr ""
@@ -43,11 +43,11 @@ msgstr ""
 msgid "File name cannot be empty."
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:227
+#: lib/components/FilePicker/FilePicker.vue:228
 msgid "Files and folders you mark as favorite will show up here."
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:225
+#: lib/components/FilePicker/FilePicker.vue:226
 msgid "Files and folders you recently modified will show up here."
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:151
+#: lib/components/FilePicker/FilePicker.vue:152
 #: lib/components/FilePicker/FilePickerNavigation.vue:61
 msgid "Recent"
 msgstr ""
@@ -94,6 +94,6 @@ msgstr ""
 msgid "Unset"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:223
+#: lib/components/FilePicker/FilePicker.vue:224
 msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -15,7 +15,8 @@
 			</div>
 
 			<!-- File list -->
-			<FileList v-if="filteredFiles.length > 0"
+			<!-- If loading or files found show file list, otherwise show empty content-->
+			<FileList v-if="isLoading || filteredFiles.length > 0"
 				:allow-pick-directory="allowPickDirectory"
 				:files="filteredFiles"
 				:multiselect="multiselect"


### PR DESCRIPTION
Backport of https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/937