### PR TITLE
[stable4] fix(FilePicker): Fix legacy entry point buttons when bundling with webpack

### DIFF
--- a/lib/legacy.ts
+++ b/lib/legacy.ts
@@ -34,8 +34,8 @@ import { t } from './utils/l10n'
 import { FilePickerVue, FilePickerType } from '.'
 
 import DialogBase from './components/DialogBase.vue'
-import IconCopy from '@mdi/svg/svg/folder-multiple.svg'
-import IconMove from '@mdi/svg/svg/folder-move.svg'
+import IconCopy from '@mdi/svg/svg/folder-multiple.svg?raw'
+import IconMove from '@mdi/svg/svg/folder-move.svg?raw'
 import Vue from 'vue'
 
 /**


### PR DESCRIPTION
When bundling with webpack (e.g. Nextcloud server) the icons are currently not displayed ("not a svg"), add `?raw` so the icons are included.