### PR TITLE
fix: dependencies and force bundle icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,18 +15,17 @@
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/typings": "^1.7.0",
         "@nextcloud/vue": "^8.0.0-beta.3",
-        "@types/toastify-js": "^1.12.0",
         "@vueuse/core": "^10.3.0",
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
-        "vue-material-design-icons": "^5.2.0",
-        "webdav": "^5.2.3"
+        "vue-material-design-icons": "^5.2.0"
       },
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.0.0",
         "@nextcloud/eslint-config": "^8.3.0-beta.2",
         "@nextcloud/vite-config": "^1.0.0-beta.18",
         "@types/gettext-parser": "^4.0.2",
+        "@types/toastify-js": "^1.12.0",
         "@vitest/coverage-istanbul": "^0.34.2",
         "@vue/test-utils": "^1.3.6",
         "@vue/tsconfig": "^0.4.0",
@@ -47,7 +46,12 @@
         "npm": "^9.0.0"
       },
       "peerDependencies": {
-        "vue": "^2.7.14"
+        "@nextcloud/files": "^3.0.0-beta.19",
+        "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/typings": "^1.7.0",
+        "@nextcloud/vue": "^8.0.0-beta.3",
+        "vue": "^2.7.14",
+        "webdav": "^5.2.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3787,7 +3791,8 @@
     "node_modules/@types/toastify-js": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@types/toastify-js/-/toastify-js-1.12.0.tgz",
-      "integrity": "sha512-fqpDHaKhFukN9KRm24bbH0wozvHmSwjvkaLjBUrWcSfSS4zysIwTYqNLG3XbSNhRlsTNRNLGS23tp/VhPwsfHQ=="
+      "integrity": "sha512-fqpDHaKhFukN9KRm24bbH0wozvHmSwjvkaLjBUrWcSfSS4zysIwTYqNLG3XbSNhRlsTNRNLGS23tp/VhPwsfHQ==",
+      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,12 @@
     "dist"
   ],
   "peerDependencies": {
-    "vue": "^2.7.14"
+    "@nextcloud/files": "^3.0.0-beta.19",
+    "@nextcloud/l10n": "^2.2.0",
+    "@nextcloud/typings": "^1.7.0",
+    "@nextcloud/vue": "^8.0.0-beta.3",
+    "vue": "^2.7.14",
+    "webdav": "^5.2.3"
   },
   "dependencies": {
     "@mdi/svg": "^7.2.96",
@@ -61,18 +66,17 @@
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/typings": "^1.7.0",
     "@nextcloud/vue": "^8.0.0-beta.3",
-    "@types/toastify-js": "^1.12.0",
     "@vueuse/core": "^10.3.0",
     "toastify-js": "^1.12.0",
     "vue-frag": "^1.4.3",
-    "vue-material-design-icons": "^5.2.0",
-    "webdav": "^5.2.3"
+    "vue-material-design-icons": "^5.2.0"
   },
   "devDependencies": {
     "@nextcloud/browserslist-config": "^3.0.0",
     "@nextcloud/eslint-config": "^8.3.0-beta.2",
     "@nextcloud/vite-config": "^1.0.0-beta.18",
     "@types/gettext-parser": "^4.0.2",
+    "@types/toastify-js": "^1.12.0",
     "@vitest/coverage-istanbul": "^0.34.2",
     "@vue/test-utils": "^1.3.6",
     "@vue/tsconfig": "^0.4.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,10 @@ export default defineConfig((env) => {
 			},
 		},
 		nodeExternalsOptions: {
-			include: [/^@nextcloud\//],
+			exclude: [
+				/^@mdi\/svg\//,
+				/^vue-material-design-icons\//,
+			]
 		},
 		libraryFormats: ['es', 'cjs'],
 		replace: {


### PR DESCRIPTION
## Why not include `@nextcloud/vue`

All node_modules are already excluded, this config is therefore unecessary

## Why adding those packages to peerDependencies

They are excluded from the output, but required/imported by this library
If we do not specify the required versions, npm will not know what to install and depend to

## Why bundling icons

Because they are static components and it's more stable this way.
It's either this or we add them into the peerDependencies, but considering the dependency mess this can create, it's simpler and steadier to just bundle them imho. The change is not that big anyway (7 KB, uncompressed)

### Before
```sh
dist/index.cjs                        0.95 kB │ gzip: 0.37 kB │ map:  0.09 kB
dist/chunks/FilePicker-bc9a2f03.cjs  20.93 kB │ gzip: 6.47 kB │ map: 51.38 kB
dist/chunks/index-2cfdbca8.cjs       85.41 kB │ gzip: 7.89 kB │ map: 57.93 kB
```

### After
```sh
dist/index.cjs                        0.95 kB │ gzip: 0.37 kB │ map:  0.09 kB
dist/chunks/FilePicker-104c4213.cjs  27.88 kB │ gzip: 7.54 kB │ map: 62.46 kB
dist/chunks/index-0065eb51.cjs       85.77 kB │ gzip: 8.10 kB │ map: 58.64 kB
```

## Why not moving webdav to devDependencies

webdav is outputed to the dist folder. I am still not sure it belongs there.
Considering this is just typings, I do wonder if we really need to expose it 
```js
grep -rn webdav dist 
dist/usables/dav.d.ts:24:import type { WebDAVClient } from 'webdav';
```

