### PR TITLE
fix: Use core preview controller for loading file previews and fallback to MDI icons

### DIFF
--- a/build/extract-l10n.js
+++ b/build/extract-l10n.js
@@ -1,23 +1,33 @@
-import { GettextExtractor, JsExtractors } from 'gettext-extractor'
+import { GettextExtractor, JsExtractors, HtmlExtractors } from 'gettext-extractor'
 
-let extractor = new GettextExtractor();
+const extractor = new GettextExtractor()
 
-extractor
-	.createJsParser([
-		JsExtractors.callExpression('t', {
-			arguments: {
-				text: 0,
-			}
-		}),
-		JsExtractors.callExpression('n', {
-			arguments: {
-				text: 1,
-				textPlural: 2,
-			}
-		}),
-	])
-	.parseFilesGlob('./lib/**/*.@(ts|js|vue)');
+const jsParser = extractor.createJsParser([
+	JsExtractors.callExpression('t', {
+		arguments: {
+			text: 0,
+		},
+	}),
+	JsExtractors.callExpression('n', {
+		arguments: {
+			text: 0,
+			textPlural: 1,
+		},
+	}),
+])
+	.parseFilesGlob('./lib/**/*.@(ts|js)')
 
-extractor.savePotFile('./l10n/messages.pot');
+extractor.createHtmlParser([
+	HtmlExtractors.embeddedJs('*', jsParser),
+	HtmlExtractors.embeddedAttributeJs(/:[a-z]+/, jsParser),
+])
+	.parseFilesGlob('./lib/**/*.vue')
 
-extractor.printStats();
+// remove references to avoid conflicts
+extractor.getMessages().forEach((msg) => {
+	msg.references = []
+})
+
+extractor.savePotFile('./l10n/messages.pot')
+
+extractor.printStats()

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,92 +2,113 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: lib/components/FilePicker/FilePickerBreadcrumbs.vue:91
 msgid "\"{name}\" is an invalid file name."
 msgstr ""
 
-#: lib/components/FilePicker/FilePickerBreadcrumbs.vue:93
 msgid "\"{name}\" is not an allowed filetype"
 msgstr ""
 
-#: lib/components/FilePicker/FilePickerBreadcrumbs.vue:89
 msgid "\"/\" is not allowed inside a file name."
 msgstr ""
 
-#: lib/components/FilePicker/FilePickerNavigation.vue:57
 msgid "All files"
 msgstr ""
 
-#: lib/filepicker.ts:207
 msgid "Choose"
 msgstr ""
 
-#: lib/filepicker.ts:207
 msgid "Choose {file}"
 msgstr ""
 
-#: lib/filepicker.ts:214
 msgid "Copy"
 msgstr ""
 
-#: lib/filepicker.ts:214
 msgid "Copy to {target}"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:249
 msgid "Could not create the new folder"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:159
-#: lib/components/FilePicker/FilePickerNavigation.vue:65
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
 msgid "Favorites"
 msgstr ""
 
-#: lib/components/FilePicker/FilePickerBreadcrumbs.vue:87
 msgid "File name cannot be empty."
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:235
+msgid "Filepicker sections"
+msgstr ""
+
 msgid "Files and folders you mark as favorite will show up here."
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:233
 msgid "Files and folders you recently modified will show up here."
 msgstr ""
 
-#: lib/components/FilePicker/FileList.vue:47
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "Mime type {mime}"
+msgstr ""
+
 msgid "Modified"
 msgstr ""
 
-#: lib/filepicker.ts:222
 msgid "Move"
 msgstr ""
 
-#: lib/filepicker.ts:222
 msgid "Move to {target}"
 msgstr ""
 
-#: lib/components/FilePicker/FileList.vue:27
 msgid "Name"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:159
-#: lib/components/FilePicker/FilePickerNavigation.vue:61
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
 msgid "Recent"
 msgstr ""
 
-#: lib/components/FilePicker/FileList.vue:8
+msgid "Select all entries"
+msgstr ""
+
 msgid "Select entry"
 msgstr ""
 
-#: lib/components/FilePicker/FileList.vue:37
+msgid "Select the row for {nodename}"
+msgstr ""
+
 msgid "Size"
 msgstr ""
 
-#: lib/toast.ts:242
 msgid "Undo"
 msgstr ""
 
-#: lib/components/FilePicker/FilePicker.vue:231
+msgid "unknown"
+msgstr ""
+
 msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/lib/components/FilePicker/FileListRow.vue
+++ b/lib/components/FilePicker/FileListRow.vue
@@ -21,7 +21,7 @@
 		</td>
 		<td class="row-name">
 			<div class="file-picker__name-container" data-testid="row-name">
-				<div class="file-picker__file-icon" :style="{ backgroundImage }" />
+				<FilePreview :node="node" />
 				<div class="file-picker__file-name" :title="displayName" v-text="displayName" />
 				<div class="file-picker__file-extension" v-text="fileExtension" />
 			</div>
@@ -35,10 +35,14 @@
 	</tr>
 </template>
 <script setup lang="ts">
-import { type Node, formatFileSize, FileType } from '@nextcloud/files'
+import type { Node } from '@nextcloud/files'
+
+import { formatFileSize, FileType } from '@nextcloud/files'
 import { NcCheckboxRadioSwitch, NcDatetime } from '@nextcloud/vue'
 import { computed } from 'vue'
 import { t } from '../../utils/l10n'
+
+import FilePreview from './FilePreview.vue'
 
 const props = defineProps<{
 	/** Can directories be picked */
@@ -79,11 +83,6 @@ const isDirectory = computed(() => props.node.type === FileType.Folder)
  * If this node can be picked, basically just check if picking a directory is allowed
  */
 const isPickable = computed(() => props.canPick && (props.allowPickDirectory || !isDirectory.value))
-
-/**
- * Background image url for the given nodes mime type
- */
-const backgroundImage = computed(() => `url(${window.OC.MimeType.getIconUrl(props.node.mime)})`)
 
 /**
  * Toggle the selection state
@@ -132,15 +131,6 @@ function handleKeyDown(event: KeyboardEvent) {
 		justify-content: start;
 		align-items: center;
 		height: 100%;
-	}
-
-	&__file-icon {
-		width: 32px;
-		height: 32px;
-		min-width: 32px;
-		min-height: 32px;
-		background-repeat: no-repeat;
-		background-size: contain;
 	}
 
 	&__file-name {

--- a/lib/components/FilePicker/FilePreview.vue
+++ b/lib/components/FilePicker/FilePreview.vue
@@ -1,0 +1,55 @@
+<template>
+	<div :style="canLoadPreview ? { backgroundImage: `url(${previewURL})`} : undefined"
+		:aria-label="t('Mime type {mime}', { mime: node.mime || t('unknown') })"
+		class="file-picker__file-icon">
+		<template v-if="!canLoadPreview">
+			<IconFile v-if="isFile" :size="20" />
+			<IconFolder v-else :size="20" />
+		</template>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { FileType, type Node } from '@nextcloud/files'
+import { usePreviewURL } from '../../usables/preview'
+import { computed, ref, toRef, watch } from 'vue'
+import { t } from '../../utils/l10n'
+
+import IconFile from 'vue-material-design-icons/File.vue'
+import IconFolder from 'vue-material-design-icons/Folder.vue'
+
+const props = defineProps<{
+	node: Node
+}>()
+
+const { previewURL } = usePreviewURL(toRef(props, 'node'))
+
+const isFile = computed(() => props.node.type === FileType.File)
+const canLoadPreview = ref(false)
+
+watch(previewURL, () => {
+	canLoadPreview.value = false
+
+	if (previewURL.value) {
+		const loader = document.createElement('img')
+		loader.src = previewURL.value.href
+		loader.onerror = () => loader.remove()
+		loader.onload = () => { canLoadPreview.value = true; loader.remove() }
+		document.body.appendChild(loader)
+	}
+}, { immediate: true })
+</script>
+
+<style scoped lang="scss">
+.file-picker__file-icon {
+	width: 32px;
+	height: 32px;
+	min-width: 32px;
+	min-height: 32px;
+	background-repeat: no-repeat;
+	background-size: contain;
+	// for the fallback
+	display: flex;
+	justify-content: center;
+}
+</style>

--- a/lib/usables/preview.spec.ts
+++ b/lib/usables/preview.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * @copyright Copyright (c) 2023 Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * @author Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { getPreviewURL, usePreviewURL } from './preview'
+import { File } from '@nextcloud/files'
+import { defineComponent, h, toRef } from 'vue'
+import { shallowMount } from '@vue/test-utils'
+
+describe('preview composable', () => {
+	const createData = (path: string, mime: string) => ({
+		owner: null,
+		source: `http://example.com/dav/${path}`,
+		mime,
+		mtime: new Date(),
+		root: '/',
+	})
+
+	describe('previewURL', () => {
+		beforeAll(() => {
+			vi.useFakeTimers()
+		})
+		afterAll(() => {
+			vi.useRealTimers()
+		})
+
+		it('is reactive', async () => {
+			const text = new File({
+				...createData('text.txt', 'text/plain'),
+				id: 1,
+			})
+			const image = new File({
+				...createData('image.png', 'image/png'),
+				id: 2,
+			})
+
+			const wrapper = shallowMount(defineComponent({
+				props: ['node'],
+				setup(props) {
+					const { previewURL } = usePreviewURL(toRef(props, 'node'))
+					return () => h('div', previewURL.value?.href)
+				},
+			}), {
+				propsData: { node: text },
+			})
+
+			expect(wrapper.text()).toMatch('/core/preview?fileId=1')
+			await wrapper.setProps({ node: image })
+			expect(wrapper.text()).toMatch('/core/preview?fileId=2')
+		})
+
+		it('uses Nodes previewUrl if available', () => {
+			const previewNode = new File({
+				...createData('text.txt', 'text/plain'),
+				attributes: {
+					previewUrl: '/preview.svg',
+				},
+			})
+			const { previewURL } = usePreviewURL(previewNode)
+
+			expect(previewURL.value?.pathname).toBe('/preview.svg')
+		})
+
+		it('works with full URL previewUrl', () => {
+			const previewNode = new File({
+				...createData('text.txt', 'text/plain'),
+				attributes: {
+					previewUrl: 'http://example.com/preview.svg',
+				},
+			})
+			const { previewURL } = usePreviewURL(previewNode)
+
+			expect(previewURL.value?.href.startsWith('http://example.com/preview.svg?')).toBe(true)
+		})
+
+		it('supports options', () => {
+			const previewNode = new File(createData('text.txt', 'text/plain'))
+
+			expect(getPreviewURL(previewNode, { size: 16 })?.searchParams.get('x')).toBe('16')
+			expect(getPreviewURL(previewNode, { size: 16 })?.searchParams.get('y')).toBe('16')
+
+			expect(getPreviewURL(previewNode, { mimeFallback: false })?.searchParams.get('mimeFallback')).toBe('false')
+		})
+	})
+})

--- a/lib/usables/preview.ts
+++ b/lib/usables/preview.ts
@@ -1,0 +1,92 @@
+/**
+ * @copyright Copyright (c) 2023 Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * @author Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Node } from '@nextcloud/files'
+import type { Ref } from 'vue'
+
+import { generateUrl } from '@nextcloud/router'
+import { toValue } from '@vueuse/core'
+import { ref, watchEffect } from 'vue'
+
+interface PreviewOptions {
+	/**
+	 * Size of the previews in px
+	 * @default 32
+	 */
+	size?: number
+	/**
+	 * Should the preview fall back to the mime type icon
+	 * @default true
+	 */
+	mimeFallback?: boolean
+	/**
+	 * Should the preview be cropped or fitted
+	 * @default false (meaning it gets fitted)
+	 */
+	cropPreview?: boolean
+}
+
+/**
+ * Generate the preview URL of a file node
+ *
+ * @param node The node to generate the preview for
+ * @param options Preview options
+ */
+export function getPreviewURL(node: Node, options: PreviewOptions = {}) {
+	options = { size: 32, cropPreview: false, mimeFallback: true, ...options }
+
+	try {
+		const previewUrl = node.attributes?.previewUrl
+			|| generateUrl('/core/preview?fileId={fileid}', {
+				fileid: node.fileid,
+			})
+
+		let url
+		try {
+			url = new URL(previewUrl)
+		} catch (e) {
+			url = new URL(previewUrl, window.location.origin)
+		}
+
+		// Request preview with params
+		url.searchParams.set('x', `${options.size}`)
+		url.searchParams.set('y', `${options.size}`)
+		url.searchParams.set('mimeFallback', `${options.mimeFallback}`)
+
+		// Handle cropping
+		url.searchParams.set('a', options.cropPreview === true ? '0' : '1')
+		return url
+	} catch (e) {
+		return null
+	}
+}
+
+export const usePreviewURL = (node: Node | Ref<Node>, options?: PreviewOptions | Ref<PreviewOptions>) => {
+	const previewURL = ref<URL|null>(null)
+
+	watchEffect(() => {
+		previewURL.value = getPreviewURL(toValue(node), toValue(options || {}))
+	})
+
+	return {
+		previewURL,
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,19 +10,19 @@
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@mdi/svg": "^7.2.96",
         "@nextcloud/files": "^3.0.0-beta.19",
         "@nextcloud/l10n": "^2.2.0",
+        "@nextcloud/router": "^2.1.2",
         "@nextcloud/typings": "^1.7.0",
         "@nextcloud/vue": "^8.0.0-beta.4",
         "@types/toastify-js": "^1.12.0",
         "@vueuse/core": "^10.4.0",
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
-        "vue-material-design-icons": "^5.2.0",
         "webdav": "^5.2.3"
       },
       "devDependencies": {
+        "@mdi/svg": "^7.2.96",
         "@nextcloud/browserslist-config": "^3.0.0",
         "@nextcloud/eslint-config": "^8.3.0-beta.2",
         "@nextcloud/vite-config": "^1.0.0-beta.18",
@@ -40,7 +40,8 @@
         "typedoc": "^0.25.0",
         "typescript": "^5.1.6",
         "vite": "^4.4.9",
-        "vitest": "^0.34.3"
+        "vitest": "^0.34.3",
+        "vue-material-design-icons": "^5.2.0"
       },
       "engines": {
         "node": "^20.0.0",
@@ -2714,7 +2715,8 @@
     "node_modules/@mdi/svg": {
       "version": "7.2.96",
       "resolved": "https://registry.npmjs.org/@mdi/svg/-/svg-7.2.96.tgz",
-      "integrity": "sha512-rxzuSL2RSt/pWWnFnUFQi5GJArm2tHMhx20Gee3Ydn+xT2bqbR4syfgdPrq2b+j+n5LjC7C8Fb1QDM6LKeF0cA=="
+      "integrity": "sha512-rxzuSL2RSt/pWWnFnUFQi5GJArm2tHMhx20Gee3Ydn+xT2bqbR4syfgdPrq2b+j+n5LjC7C8Fb1QDM6LKeF0cA==",
+      "dev": true
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.36.4",

--- a/package.json
+++ b/package.json
@@ -56,19 +56,19 @@
     "vue": "^2.7.14"
   },
   "dependencies": {
-    "@mdi/svg": "^7.2.96",
     "@nextcloud/files": "^3.0.0-beta.19",
     "@nextcloud/l10n": "^2.2.0",
+    "@nextcloud/router": "^2.1.2",
     "@nextcloud/typings": "^1.7.0",
     "@nextcloud/vue": "^8.0.0-beta.4",
     "@types/toastify-js": "^1.12.0",
     "@vueuse/core": "^10.4.0",
     "toastify-js": "^1.12.0",
     "vue-frag": "^1.4.3",
-    "vue-material-design-icons": "^5.2.0",
     "webdav": "^5.2.3"
   },
   "devDependencies": {
+    "@mdi/svg": "^7.2.96",
     "@nextcloud/browserslist-config": "^3.0.0",
     "@nextcloud/eslint-config": "^8.3.0-beta.2",
     "@nextcloud/vite-config": "^1.0.0-beta.18",
@@ -86,7 +86,8 @@
     "typedoc": "^0.25.0",
     "typescript": "^5.1.6",
     "vite": "^4.4.9",
-    "vitest": "^0.34.3"
+    "vitest": "^0.34.3",
+    "vue-material-design-icons": "^5.2.0"
   },
   "engines": {
     "node": "^20.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,10 @@ export default defineConfig((env) => {
 			},
 		},
 		nodeExternalsOptions: {
+			// for subpath imports like '@nextcloud/l10n/gettext'
 			include: [/^@nextcloud\//],
+			// we should externalize vue SFC dependencies
+			exclude: [/^vue-material-design-icons\//, /\.vue(\?|$)/],
 		},
 		libraryFormats: ['es', 'cjs'],
 		replace: {


### PR DESCRIPTION
* Use preview controller instead of deprecated OC API
  * resolves #943 
* Fallback to MDI 20px icons for files if there is no preview
  * part of #920 
* Fix l10n issue: Translations in vue templates were not extracted