### PR TITLE
fix(FilePicker): Reset selected files if the current directory is changed

### DIFF
--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -191,6 +191,8 @@ const currentPath = computed({
 			window.sessionStorage.setItem('NC.FilePicker.LastPath', path)
 		}
 		navigatedPath.value = path
+		// Reset selected files
+		selectedFiles.value = []
 	},
 })
 


### PR DESCRIPTION
Bring back the legacy behavior (which I think makes even more sense).