### PR TITLE
fix(FilePicker): Only show checkbox skeletons if multiselect was enabled

### DIFF
--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -51,7 +51,7 @@
 			</thead>
 			<tbody>
 				<template v-if="loading">
-					<LoadingTableRow v-for="i in [1, 2, 3, 4]" :key="i" />
+					<LoadingTableRow v-for="i in [1, 2, 3, 4]" :key="i" :show-checkbox="multiselect"/>
 				</template>
 				<template v-else>
 					<FileListRow v-for="file in sortedFiles"

--- a/lib/components/FilePicker/LoadingTableRow.vue
+++ b/lib/components/FilePicker/LoadingTableRow.vue
@@ -1,7 +1,7 @@
 <!-- Simple component to fake a loading table row with placeholders -->
 <template>
 	<tr aria-hidden="true" class="file-picker__row loading-row">
-		<td class="row-checkbox">
+		<td v-if="showCheckbox" class="row-checkbox">
 			<span />
 		</td>
 		<td class="row-name">
@@ -15,6 +15,15 @@
 		</td>
 	</tr>
 </template>
+
+<script setup lang="ts">
+defineProps<{
+	/**
+	 * Does the filelist use the checkbox column
+	 */
+	showCheckbox: boolean
+}>()
+</script>
 
 <style scoped lang="scss">
 @use './FileList.scss';


### PR DESCRIPTION
before | after
---|---
![Screenshot_20230828_174223](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/a3f929bc-c582-4cbd-9228-506b6604166e)|![Screenshot_20230828_174235](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/4f09ea67-6de8-4ace-9128-972d90e3ea64)
