### PR TITLE
[stable4] fix(FilePicker): Only show checkbox skeletons if multiselect was enabled

### DIFF
--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -51,7 +51,7 @@
 			</thead>
 			<tbody>
 				<template v-if="loading">
-					<LoadingTableRow v-for="i in [1, 2, 3, 4]" :key="i" />
+					<LoadingTableRow v-for="i in [1, 2, 3, 4]" :key="i" :show-checkbox="multiselect"/>
 				</template>
 				<template v-else>
 					<FileListRow v-for="file in sortedFiles"

--- a/lib/components/FilePicker/LoadingTableRow.vue
+++ b/lib/components/FilePicker/LoadingTableRow.vue
@@ -1,7 +1,7 @@
 <!-- Simple component to fake a loading table row with placeholders -->
 <template>
 	<tr aria-hidden="true" class="file-picker__row loading-row">
-		<td class="row-checkbox">
+		<td v-if="showCheckbox" class="row-checkbox">
 			<span />
 		</td>
 		<td class="row-name">
@@ -15,6 +15,15 @@
 		</td>
 	</tr>
 </template>
+
+<script setup lang="ts">
+defineProps<{
+	/**
+	 * Does the filelist use the checkbox column
+	 */
+	showCheckbox: boolean
+}>()
+</script>
 
 <style scoped lang="scss">
 @use './FileList.scss';


### PR DESCRIPTION
* backport of https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/969