### PR TITLE
Fix styling issues and make the FilePicker height fixed

### DIFF
--- a/lib/components/DialogBase.vue
+++ b/lib/components/DialogBase.vue
@@ -5,14 +5,14 @@
 		@close="handleClose">
 		<!-- The dialog name / header -->
 		<h2 class="dialog__name" v-text="name" />
-		<div class="dialog">
+		<div class="dialog" :class="dialogClasses">
 			<div ref="wrapper" :class="['dialog__wrapper', { 'dialog__wrapper--collapsed': isNavigationCollapsed }]">
 				<!-- When the navigation is collapsed (too small dialog) it is displayed above the main content, otherwise on the inline start -->
-				<nav v-if="hasNavigation" :class="['dialog__navigation', ...navigationClasses]">
+				<nav v-if="hasNavigation" class="dialog__navigation" :class="navigationClasses">
 					<slot name="navigation" :is-collapsed="isNavigationCollapsed" />
 				</nav>
 				<!-- Main dialog content -->
-				<div :class="['dialog__content', ...contentClasses]">
+				<div class="dialog__content" :class="contentClasses">
 					<slot>
 						<p>{{ props.message }}</p>
 					</slot>
@@ -32,10 +32,13 @@
 </template>
 
 <script setup lang="ts">
+import type { IDialogButton } from './types'
+
 import { NcModal } from '@nextcloud/vue'
-import { computed, ref, useSlots } from 'vue'
-import DialogButton, { type IDialogButton } from './DialogButton.vue'
 import { useElementSize } from '@vueuse/core'
+import { computed, ref, useSlots } from 'vue'
+
+import DialogButton from './DialogButton.vue'
 
 const props = withDefaults(defineProps<{
 	/** Name of the dialog (the heading) */
@@ -79,12 +82,18 @@ const props = withDefaults(defineProps<{
 	 * @default []
 	 */
 	contentClasses?: string[]
+	/**
+	 * Optionally pass additionaly classes which will be set on the dialog itself
+	 * (the default `class` attribute will be set on the modal wrapper)
+	 */
+	dialogClasses?: string|Record<string, boolean>|(string|Record<string, boolean>)[]
 }>(), {
 	additionalTrapElements: () => [],
 	buttons: () => [],
 	container: undefined,
 	message: '',
 	contentClasses: () => [],
+	dialogClasses: () => [],
 	navigationClasses: () => [],
 	size: 'small',
 })

--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -190,8 +190,8 @@ function onChangeDirectory(dir: Node) {
 .file-picker {
 	&__files {
 		// ensure focus outlines are visible
-		padding: 2px;
-		padding-inline-start: 12px; // align with bread crumbs
+		margin: 2px;
+		margin-inline-start: 12px; // align with bread crumbs
 		min-height: calc(5 * var(--row-height, 50px)); // make file list not jumping when loading (1x header 4x loading placeholders)
 		overflow: scroll auto;
 

--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -259,8 +259,6 @@ export default {
 
 <style scoped lang="scss">
 .file-picker {
-	height: min(80vh, 800px); // Dialog is max. 900px wide so the best looking height seems to be 800px
-
 	&__view {
 		height: 50px; // align with breadcrumbs
 		display: flex;
@@ -286,6 +284,18 @@ export default {
 		* {
 			box-sizing: border-box;
 		}
+	}
+}
+
+:deep(.file-picker) {
+	// Dialog is max. 900px wide so the best looking height seems to be 800px
+	height: min(80vh, 800px);
+}
+
+@media (max-width: 512px) {
+	:deep(.file-picker) {
+		// below 512px the modal is fullscreen so we use 100% height - margin of heading (4px + 12px) - height of heading (default-clickable-area)
+		height: calc(100% - 16px - var(--default-clickable-area));
 	}
 }
 

--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -126,8 +126,9 @@ const dialogProps = computed(() => ({
 	name: props.name,
 	buttons: dialogButtons.value,
 	size: 'large',
-	navigationClasses: ['file-picker__navigation'],
 	contentClasses: ['file-picker__content'],
+	dialogClasses: ['file-picker'],
+	navigationClasses: ['file-picker__navigation'],
 }))
 
 /**
@@ -258,10 +259,7 @@ export default {
 
 <style scoped lang="scss">
 .file-picker {
-	display: flex;
-	flex-direction: row;
-	min-height: 40vh;
-	gap: 22px;
+	height: min(80vh, 800px); // Dialog is max. 900px wide so the best looking height seems to be 800px
 
 	&__view {
 		height: 50px; // align with breadcrumbs
@@ -294,5 +292,6 @@ export default {
 :deep(.file-picker__content) {
 	display: flex;
 	flex-direction: column;
+	overflow: hidden;
 }
 </style>

--- a/lib/components/FilePicker/FilePickerNavigation.vue
+++ b/lib/components/FilePicker/FilePickerNavigation.vue
@@ -101,6 +101,8 @@ const updateFilterValue = (value: string) => emit('update:filterString', value)
 		min-width: 200px;
 		// ensure focus outline is visible
 		padding-block: 2px;
+		// make only the navigation scroll
+		overflow: auto;
 
 		:deep(.button-vue__wrapper) {
 			justify-content: start;


### PR DESCRIPTION
* Resolves #900 

This fixes some remaining styling issues and the second commit sets a fixed height to the file picker.
We already have a max. width of 900px and a max. height of 90% from the modal.

So from my perspective a height of max. 800px looks good (900x800px), thats why I set the height to `min(80vh, 800px)`.

small | medium | large
---|---|---
![Screen Shot 2023-08-28 at 21 27 42](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/7cab8ad5-133b-4f3e-a2f3-2f4e641a632f)|![Screen Shot 2023-08-28 at 21 27 50](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/20242ce9-c984-4084-8396-bd96b8f22a61)|![Screen Shot 2023-08-28 at 21 27 57](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/d6408009-6f3c-4d1a-9057-045057345d45)
