### PR TITLE
[stable4] fix(Dialog): Make the dialog flex column to show headline on top of content

### DIFF
--- a/lib/components/DialogBase.vue
+++ b/lib/components/DialogBase.vue
@@ -162,6 +162,7 @@ const modalProps = computed(() => ({
 	&__modal {
 		:deep(.modal-container) {
 			display: flex !important;
+			flex-direction: column;
 		}
 	}
 


### PR DESCRIPTION
Regression of #972 

### screenshots
before | after
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/f5bb4d3e-be97-4eac-9058-a5dbd6e3109f)|![](https://user-images.githubusercontent.com/1855448/267620260-77cdcdde-7a57-45e5-b740-4480b94bb4d4.png)