### PR TITLE
fix(FilePicker): Ensure file list header is shown on top of scrolled content rows

### DIFF
--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -236,6 +236,7 @@ const fileContainer = ref<HTMLDivElement>()
 		}
 		th {
 			position: sticky;
+			z-index: 1; // show on top of scrolled content rows
 			top: 0;
 			background-color: var(--color-main-background);
 			// ensure focus outline of buttons is visible


### PR DESCRIPTION
before | after
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/7b452573-4d61-4b9f-9a20-1caac837199e)|![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/1855448/bd0098cb-4e01-4d6b-a9ce-e956849bfe85)
