### PR TITLE
[stable4] fix(FilePicker): Ensure file list header is shown on top of scrolled content rows

### DIFF
--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -236,6 +236,7 @@ const fileContainer = ref<HTMLDivElement>()
 		}
 		th {
 			position: sticky;
+			z-index: 1; // show on top of scrolled content rows
 			top: 0;
 			background-color: var(--color-main-background);
 			// ensure focus outline of buttons is visible


### PR DESCRIPTION
backport of https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/997