### PR TITLE
[stable4] Avoid error when not using any custom buttons

### DIFF
--- a/lib/filepicker.ts
+++ b/lib/filepicker.ts
@@ -143,7 +143,7 @@ export class FilePickerBuilder {
 	}
 
 	public build(): FilePicker {
-		if (this.buttons && this.type !== FilePickerType.Custom) {
+		if (this.buttons?.length > 0 && this.type !== FilePickerType.Custom) {
 			console.error('FilePickerBuilder: When adding custom buttons the `type` must be set to `FilePickerType.Custom`.')
 		}
 


### PR DESCRIPTION
Avoid logging a console error if no buttons are provided and the default Choose type is used, e.g. when calling in text: 

https://github.com/nextcloud/text/blob/22318ffc88100d6912f586cf2594b65200f4f063/src/components/Editor/MediaHandler.vue#L162-L165