### PR TITLE
[stable4] fix: Swap sort icons

### DIFF
--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -80,8 +80,8 @@ import { join } from 'path'
 import { t } from '../../utils/l10n'
 import { computed, nextTick, onMounted, onUnmounted, ref, type Ref } from 'vue'
 
-import IconSortAscending from 'vue-material-design-icons/MenuDown.vue'
-import IconSortDescending from 'vue-material-design-icons/MenuUp.vue'
+import IconSortAscending from 'vue-material-design-icons/MenuUp.vue'
+import IconSortDescending from 'vue-material-design-icons/MenuDown.vue'
 import LoadingTableRow from './LoadingTableRow.vue'
 import FileListRow from './FileListRow.vue'
 


### PR DESCRIPTION
Backport https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1058