### PR TITLE
fix(FilePicker): Make the validity strings more specific

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,13 +2,13 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-msgid "\"{name}\" is an invalid file name."
+msgid "\"{name}\" is an invalid folder name."
 msgstr ""
 
-msgid "\"{name}\" is not an allowed filetype"
+msgid "\"{name}\" is not an allowed folder name"
 msgstr ""
 
-msgid "\"/\" is not allowed inside a file name."
+msgid "\"/\" is not allowed inside a folder name."
 msgstr ""
 
 msgid "All files"
@@ -38,9 +38,6 @@ msgstr ""
 msgid "Favorites"
 msgstr ""
 
-msgid "File name cannot be empty."
-msgstr ""
-
 msgid "Filepicker sections"
 msgstr ""
 
@@ -51,6 +48,9 @@ msgid "Files and folders you recently modified will show up here."
 msgstr ""
 
 msgid "Filter file list"
+msgstr ""
+
+msgid "Folder name cannot be empty."
 msgstr ""
 
 msgid "Home"

--- a/lib/components/FilePicker/FilePickerBreadcrumbs.vue
+++ b/lib/components/FilePicker/FilePickerBreadcrumbs.vue
@@ -84,13 +84,13 @@ function validateInput() {
 
 	let validity = ''
 	if (name.length === 0) {
-		validity = t('File name cannot be empty.')
+		validity = t('Folder name cannot be empty.')
 	} else if (name.includes('/')) {
-		validity = t('"/" is not allowed inside a file name.')
+		validity = t('"/" is not allowed inside a folder name.')
 	} else if (['..', '.'].includes(name)) {
-		validity = t('"{name}" is an invalid file name.', { name })
+		validity = t('"{name}" is an invalid folder name.', { name })
 	} else if (window.OC.config?.blacklist_files_regex && name.match(window.OC.config?.blacklist_files_regex)) {
-		validity = t('"{name}" is not an allowed filetype', { name })
+		validity = t('"{name}" is not an allowed folder name', { name })
 	}
 	if (input) {
 		input.setCustomValidity(validity)


### PR DESCRIPTION
As per https://github.com/nextcloud/server/issues/37019 the error message should be more specific (it is a folder and not a file)