### PR TITLE
fix(l10n): Update translations from main

### DIFF
--- a/l10n/af.pot
+++ b/l10n/af.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Afrikaans (https://app.transifex.com/nextcloud/teams/64236/af/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Afrikaans (https://app.transifex.com/nextcloud/teams/64236/"
+"af/)\n"
 "Language: af\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/ar.pot
+++ b/l10n/ar.pot
@@ -1,15 +1,139 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Ali <alimahwer@yahoo.com>, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
+"Last-Translator: Ali <alimahwer@yahoo.com>, 2023\n"
 "Language-Team: Arabic (https://app.transifex.com/nextcloud/teams/64236/ar/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: ar\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "كل الملفات"
+
+msgid "Choose"
+msgstr "إختَر"
+
+msgid "Choose {file}"
+msgstr "إختَر {file}"
+
+msgid "Copy"
+msgstr "نسخ"
+
+msgid "Copy to {target}"
+msgstr "نسخٌ إلى {target}"
+
+msgid "Could not create the new folder"
+msgstr "تعذّر إنشاء المجلد الجديد"
+
+msgid "Create directory"
+msgstr "أنشِيءْ مجلّداً"
+
+msgid "Current view selector"
+msgstr "مُنتقِي المنظور الحالي"
+
+msgid "Favorites"
+msgstr "المُفضَّلة"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "أقسام مُنتقِي الملفات"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "الملفات و المجلدات التي تُميِّزُها كمٌفضَّلة ستظهر هنا."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "الملفات و المجلدات التي قمت مؤخراً بتعديلها سوف تظهر هنا."
+
+msgid "Filter file list"
+msgstr "فلترة قائمة الملفات"
+
+msgid "Home"
+msgstr "البداية"
+
+msgid "MIME type {mime}"
+msgstr "نوع الملف {mime}"
+
+msgid "Modified"
+msgstr "مُعدَّل"
+
+msgid "Move"
+msgstr "أُنقُل"
+
+msgid "Move to {target}"
+msgstr "أُنقُل إلى {target}"
+
+msgid "Name"
+msgstr "الاسم"
+
+msgid "New"
+msgstr "جديد"
+
+msgid "New folder"
+msgstr "مٌجلّد جديد"
+
+msgid "New folder name"
+msgstr "اسم المجلد الجديد"
+
+msgid "No files in here"
+msgstr "لا توجد ملفات هنا"
+
+msgid "No files matching your filter were found."
+msgstr "لا توجد ملفات تتطابق مع الفلتر الذي وضعته"
+
+msgid "No matching files"
+msgstr "لا توجد ملفات مُطابِقة"
+
+msgid "Recent"
+msgstr "الحالي"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "حدِّد كل المداخل"
+
+msgid "Select entry"
+msgstr "إختَر المدخل"
+
+msgid "Select the row for {nodename}"
+msgstr "إختر سطر الـ {nodename}"
+
+msgid "Size"
+msgstr "الحجم"
+
 msgid "Undo"
 msgstr "تراجع"
+
+msgid "unknown"
+msgstr "غير محدد"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "قُم برفع محتوىً أو قُم بمزامنة أجهزتك!"
+

--- a/l10n/ast.pot
+++ b/l10n/ast.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Asturian (https://app.transifex.com/nextcloud/teams/64236/ast/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Asturian (https://app.transifex.com/nextcloud/teams/64236/"
+"ast/)\n"
 "Language: ast\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Desfacer"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/az.pot
+++ b/l10n/az.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Azerbaijani (https://app.transifex.com/nextcloud/teams/64236/az/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Azerbaijani (https://app.transifex.com/nextcloud/teams/64236/"
+"az/)\n"
 "Language: az\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/be.pot
+++ b/l10n/be.pot
@@ -1,15 +1,139 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Belarusian (https://app.transifex.com/nextcloud/teams/64236/be/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Belarusian (https://app.transifex.com/nextcloud/teams/64236/"
+"be/)\n"
 "Language: be\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/bg_BG.pot
+++ b/l10n/bg_BG.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/nextcloud/teams/64236/bg_BG/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/nextcloud/"
+"teams/64236/bg_BG/)\n"
 "Language: bg_BG\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/bn_BD.pot
+++ b/l10n/bn_BD.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Bengali (Bangladesh) (https://app.transifex.com/nextcloud/teams/64236/bn_BD/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Bengali (Bangladesh) (https://app.transifex.com/nextcloud/"
+"teams/64236/bn_BD/)\n"
 "Language: bn_BD\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/br.pot
+++ b/l10n/br.pot
@@ -1,15 +1,140 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Breton (https://app.transifex.com/nextcloud/teams/64236/br/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: br\n"
-"Plural-Forms: nplurals=5; plural=((n%10 == 1) && (n%100 != 11) && (n%100 !=71) && (n%100 !=91) ? 0 :(n%10 == 2) && (n%100 != 12) && (n%100 !=72) && (n%100 !=92) ? 1 :(n%10 ==3 || n%10==4 || n%10==9) && (n%100 < 10 || n% 100 > 19) && (n%100 < 70 || n%100 > 79) && (n%100 < 90 || n%100 > 99) ? 2 :(n != 0 && n % 1000000 == 0) ? 3 : 4);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=5; plural=((n%10 == 1) && (n%100 != 11) && (n%100 !"
+"=71) && (n%100 !=91) ? 0 :(n%10 == 2) && (n%100 != 12) && (n%100 !=72) && "
+"(n%100 !=92) ? 1 :(n%10 ==3 || n%10==4 || n%10==9) && (n%100 < 10 || n% 100 "
+"> 19) && (n%100 < 70 || n%100 > 79) && (n%100 < 90 || n%100 > 99) ? 2 :(n != "
+"0 && n % 1000000 == 0) ? 3 : 4);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Disober"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/bs.pot
+++ b/l10n/bs.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Bosnian (https://app.transifex.com/nextcloud/teams/64236/bs/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Bosnian (https://app.transifex.com/nextcloud/teams/64236/"
+"bs/)\n"
 "Language: bs\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/ca.pot
+++ b/l10n/ca.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Catalan (https://app.transifex.com/nextcloud/teams/64236/ca/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Catalan (https://app.transifex.com/nextcloud/teams/64236/"
+"ca/)\n"
 "Language: ca\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Desfés"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/cs.pot
+++ b/l10n/cs.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Pavel Borecki <pavel.borecki@gmail.com>, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>, 2020\n"
 "Language-Team: Czech (https://www.transifex.com/nextcloud/teams/64236/cs/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: cs\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-#: lib/toast.ts:187
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Zpět"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/cs_CZ.pot
+++ b/l10n/cs_CZ.pot
@@ -1,15 +1,140 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Pavel Borecki <pavel.borecki@gmail.com>, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Czech (Czech Republic) (https://app.transifex.com/nextcloud/teams/64236/cs_CZ/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>, 2023\n"
+"Language-Team: Czech (Czech Republic) (https://app.transifex.com/nextcloud/"
+"teams/64236/cs_CZ/)\n"
 "Language: cs_CZ\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Veškeré soubory"
+
+msgid "Choose"
+msgstr "Zvolit"
+
+msgid "Choose {file}"
+msgstr "Zvolit {file}"
+
+msgid "Copy"
+msgstr "Zkopírovat"
+
+msgid "Copy to {target}"
+msgstr "Zkopírovat do {target}"
+
+msgid "Could not create the new folder"
+msgstr "Novou složku se nepodařilo vytvořit"
+
+msgid "Create directory"
+msgstr "Vytvořit složku"
+
+msgid "Current view selector"
+msgstr "Výběr stávajícího zobrazení"
+
+msgid "Favorites"
+msgstr "Oblíbené"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "Sekce dialogu pro výběr souboru"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Zde se zobrazí soubory a složky, které označíte jako oblíbené."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Zde se zobrazí soubory a složky, které jste nedávno pozměnili."
+
+msgid "Filter file list"
+msgstr "Filtrovat seznam souborů"
+
+msgid "Home"
+msgstr "Domů"
+
+msgid "MIME type {mime}"
+msgstr "MIME typ {mime}"
+
+msgid "Modified"
+msgstr "Změněno"
+
+msgid "Move"
+msgstr "Přesounout"
+
+msgid "Move to {target}"
+msgstr "Přesunout do {target}"
+
+msgid "Name"
+msgstr "Název"
+
+msgid "New"
+msgstr "Nové"
+
+msgid "New folder"
+msgstr "Nová složka"
+
+msgid "New folder name"
+msgstr "Název pro novou složku"
+
+msgid "No files in here"
+msgstr "Nejsou zde žádné soubory"
+
+msgid "No files matching your filter were found."
+msgstr "Nenalezeny žádné soubory odpovídající vašemu filtru"
+
+msgid "No matching files"
+msgstr "Žádné odpovídající soubory"
+
+msgid "Recent"
+msgstr "Nedávné"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Vybrat všechny položky"
+
+msgid "Select entry"
+msgstr "Vybrat položku"
+
+msgid "Select the row for {nodename}"
+msgstr "Vybrat řádek pro {nodename}"
+
+msgid "Size"
+msgstr "Velikost"
+
 msgid "Undo"
 msgstr "Zpět"
+
+msgid "unknown"
+msgstr "neznámé"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Nahrajte nějaký obsah nebo proveďte synchronizaci se svými zařízeními!"
+

--- a/l10n/cy_GB.pot
+++ b/l10n/cy_GB.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Welsh (United Kingdom) (https://app.transifex.com/nextcloud/teams/64236/cy_GB/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Welsh (United Kingdom) (https://app.transifex.com/nextcloud/"
+"teams/64236/cy_GB/)\n"
 "Language: cy_GB\n"
-"Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != "
+"11) ? 2 : 3;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/da.pot
+++ b/l10n/da.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Danish (https://app.transifex.com/nextcloud/teams/64236/da/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: da\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Fortryd"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/de.pot
+++ b/l10n/de.pot
@@ -1,15 +1,140 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Mario Siegmann <mario_siegmann@web.de>, 2023
+# Markus Eckstein, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
+"Last-Translator: Markus Eckstein, 2023\n"
 "Language-Team: German (https://app.transifex.com/nextcloud/teams/64236/de/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: de\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr "\"{name}\" ist ein ungültiger Dateiname."
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr "\"{name}\" ist kein zulässiger Dateityp."
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr "\"/\" ist innerhalb eines Dateinamens nicht zulässig."
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Alle Dateien"
+
+msgid "Choose"
+msgstr "Auswählen"
+
+msgid "Choose {file}"
+msgstr "{file} auswählen"
+
+msgid "Copy"
+msgstr "Kopieren"
+
+msgid "Copy to {target}"
+msgstr "Nach {target} kopieren"
+
+msgid "Could not create the new folder"
+msgstr "Der neue Ordner konnte nicht erstellt werden."
+
+msgid "Create directory"
+msgstr "Verzeichnis erstellen"
+
+msgid "Current view selector"
+msgstr "Aktuelle Ansichtsauswahl"
+
+msgid "Favorites"
+msgstr "Favoriten"
+
+msgid "File name cannot be empty."
+msgstr "Der Dateiname darf nicht leer sein."
+
+msgid "Filepicker sections"
+msgstr "Filepicker-Auswahl"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+"Dateien und Ordner, die du als Favorit markierst, werden hier angezeigt."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+"Dateien und Ordner, die du kürzlich geändert hast, werden hier angezeigt."
+
+msgid "Filter file list"
+msgstr "Dateiliste filtern"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "MIME type {mime}"
+msgstr "MIME-Typ {mime}"
+
+msgid "Modified"
+msgstr "Geändert"
+
+msgid "Move"
+msgstr "Verschieben"
+
+msgid "Move to {target}"
+msgstr "Nach {target} verschieben"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "New"
+msgstr "Neu"
+
+msgid "New folder"
+msgstr "Neuer Ordner"
+
+msgid "New folder name"
+msgstr "Neuer Ordnername"
+
+msgid "No files in here"
+msgstr "Hier sind keine Dateien"
+
+msgid "No files matching your filter were found."
+msgstr "Es wurden keine Dateien gefunden, die deinem Filter entsprechen."
+
+msgid "No matching files"
+msgstr "Keine passenden Dateien"
+
+msgid "Recent"
+msgstr "Jüngste"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Alle Einträge auswählen"
+
+msgid "Select entry"
+msgstr "Eintrag auswählen"
+
+msgid "Select the row for {nodename}"
+msgstr "Die Zeile für {nodename} auswählen."
+
+msgid "Size"
+msgstr "Größe"
+
 msgid "Undo"
 msgstr "Rückgängig"
+
+msgid "unknown"
+msgstr "Unbekannt"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Lade Inhalte hoch oder synchronisieren diese mit deinen Geräten!"

--- a/l10n/de_DE.pot
+++ b/l10n/de_DE.pot
@@ -1,15 +1,143 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Mark Ziegler <mark.ziegler@rakekniven.de>, 2023
+# Mario Siegmann <mario_siegmann@web.de>, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: German (Germany) (https://app.transifex.com/nextcloud/teams/64236/de_DE/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Mario Siegmann <mario_siegmann@web.de>, 2023\n"
+"Language-Team: German (Germany) (https://app.transifex.com/nextcloud/"
+"teams/64236/de_DE/)\n"
 "Language: de_DE\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Alle Dateien"
+
+msgid "Choose"
+msgstr "Auswählen"
+
+msgid "Choose {file}"
+msgstr "{file} auswählen"
+
+msgid "Copy"
+msgstr "Kopieren"
+
+msgid "Copy to {target}"
+msgstr "Nach {target} kopieren"
+
+msgid "Could not create the new folder"
+msgstr "Der neue Ordner konnte nicht erstellt werden"
+
+msgid "Create directory"
+msgstr "Verzeichnis erstellen"
+
+msgid "Current view selector"
+msgstr "Aktuelle Ansichtsauswahl"
+
+msgid "Favorites"
+msgstr "Favoriten"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "Dateiauswahl-Bereiche"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+"Dateien und Ordner, die Sie als Favorit markieren, werden hier angezeigt."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+"Dateien und Ordner, die Sie kürzlich geändert haben, werden hier angezeigt."
+
+msgid "Filter file list"
+msgstr "Dateiliste filtern"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "MIME type {mime}"
+msgstr "MIME-Typ {mime}"
+
+msgid "Modified"
+msgstr "Geändert"
+
+msgid "Move"
+msgstr "Verschieben"
+
+msgid "Move to {target}"
+msgstr "Nach {target} verschieben"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "New"
+msgstr "Neu"
+
+msgid "New folder"
+msgstr "Neuer Ordner"
+
+msgid "New folder name"
+msgstr "Neuer Ordnername"
+
+msgid "No files in here"
+msgstr "Hier sind keine Dateien"
+
+msgid "No files matching your filter were found."
+msgstr "Es wurden keine Dateien gefunden, die Ihrem Filter entsprechen."
+
+msgid "No matching files"
+msgstr "Keine passenden Dateien"
+
+msgid "Recent"
+msgstr "Neueste"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Alle Einträge auswählen"
+
+msgid "Select entry"
+msgstr "Eintrag auswählen"
+
+msgid "Select the row for {nodename}"
+msgstr "Die Zeile für {nodename} auswählen."
+
+msgid "Size"
+msgstr "Größe"
+
 msgid "Undo"
 msgstr "Rückgängig machen"
+
+msgid "unknown"
+msgstr "Unbekannt"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""
+"Laden Sie Inhalte hoch oder synchronisieren Sie diese mit Ihren Geräten!"
+

--- a/l10n/el.pot
+++ b/l10n/el.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Greek (https://app.transifex.com/nextcloud/teams/64236/el/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: el\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Αναίρεση"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/en_GB.pot
+++ b/l10n/en_GB.pot
@@ -1,15 +1,139 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Andi Chandler <andi@gowling.com>, 2023
+# Café Tango, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: English (United Kingdom) (https://app.transifex.com/nextcloud/teams/64236/en_GB/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Café Tango, 2023\n"
+"Language-Team: English (United Kingdom) (https://app.transifex.com/nextcloud/"
+"teams/64236/en_GB/)\n"
 "Language: en_GB\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr "\"{name}\" is an invalid file name."
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr "\"{name}\" is not an allowed filetype"
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr "\"/\" is not allowed inside a file name."
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "All files"
+
+msgid "Choose"
+msgstr "Choose"
+
+msgid "Choose {file}"
+msgstr "Choose {file}"
+
+msgid "Copy"
+msgstr "Copy"
+
+msgid "Copy to {target}"
+msgstr "Copy to {target}"
+
+msgid "Could not create the new folder"
+msgstr "Could not create the new folder"
+
+msgid "Create directory"
+msgstr "Create directory"
+
+msgid "Current view selector"
+msgstr "Current view selector"
+
+msgid "Favorites"
+msgstr "Favourites"
+
+msgid "File name cannot be empty."
+msgstr "File name cannot be empty."
+
+msgid "Filepicker sections"
+msgstr "Filepicker sections"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Files and folders you mark as favourite will show up here."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Files and folders you recently modified will show up here."
+
+msgid "Filter file list"
+msgstr "Filter file list"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "MIME type {mime}"
+msgstr "MIME type {mime}"
+
+msgid "Modified"
+msgstr "Modified"
+
+msgid "Move"
+msgstr "Move"
+
+msgid "Move to {target}"
+msgstr "Move to {target}"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "New"
+msgstr "New"
+
+msgid "New folder"
+msgstr "New folder"
+
+msgid "New folder name"
+msgstr "New folder name"
+
+msgid "No files in here"
+msgstr "No files in here"
+
+msgid "No files matching your filter were found."
+msgstr "No files matching your filter were found."
+
+msgid "No matching files"
+msgstr "No matching files"
+
+msgid "Recent"
+msgstr "Recent"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Select all entries"
+
+msgid "Select entry"
+msgstr "Select entry"
+
+msgid "Select the row for {nodename}"
+msgstr "Select the row for {nodename}"
+
+msgid "Size"
+msgstr "Size"
+
 msgid "Undo"
 msgstr "Undo"
+
+msgid "unknown"
+msgstr "unknown"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Upload some content or sync with your devices!"

--- a/l10n/eo.pot
+++ b/l10n/eo.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Esperanto (https://app.transifex.com/nextcloud/teams/64236/eo/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Esperanto (https://app.transifex.com/nextcloud/teams/64236/"
+"eo/)\n"
 "Language: eo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Malfari"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/es.pot
+++ b/l10n/es.pot
@@ -1,15 +1,140 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# FranciscoFJ <dev-ooo@satel-sa.com>, 2023
+# Julio C. Ortega, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Spanish (https://app.transifex.com/nextcloud/teams/64236/es/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Julio C. Ortega, 2023\n"
+"Language-Team: Spanish (https://app.transifex.com/nextcloud/teams/64236/"
+"es/)\n"
 "Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr "\"{name}\" es un nombre de archivo inválido."
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr "\"{name}\" es un tipo de archivo no permitido"
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr "\"/\" no está permitido dentro del nombre de un archivo."
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Todos los archivos"
+
+msgid "Choose"
+msgstr "Escoger"
+
+msgid "Choose {file}"
+msgstr "Escoger {file}"
+
+msgid "Copy"
+msgstr "Copiar"
+
+msgid "Copy to {target}"
+msgstr "Copiar a {target}"
+
+msgid "Could not create the new folder"
+msgstr "No se pudo crear la carpeta nueva"
+
+msgid "Create directory"
+msgstr "Crear directorio"
+
+msgid "Current view selector"
+msgstr "Selector de vista actual"
+
+msgid "Favorites"
+msgstr "Favoritos"
+
+msgid "File name cannot be empty."
+msgstr "El nombre de archivo no puede estar vacío."
+
+msgid "Filepicker sections"
+msgstr "Secciones del selector de archivos"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Los archivos y carpetas que marque como favoritos aparecerán aquí."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Los archivos y carpetas que modificó recientemente aparecerán aquí."
+
+msgid "Filter file list"
+msgstr "Filtrar lista de archivos"
+
+msgid "Home"
+msgstr "Inicio"
+
+msgid "MIME type {mime}"
+msgstr "Tipo MIME {mime}"
+
+msgid "Modified"
+msgstr "Modificado"
+
+msgid "Move"
+msgstr "Mover"
+
+msgid "Move to {target}"
+msgstr "Mover a {target}"
+
+msgid "Name"
+msgstr "Nombre"
+
+msgid "New"
+msgstr "Nuevo"
+
+msgid "New folder"
+msgstr " Nueva carpeta"
+
+msgid "New folder name"
+msgstr "Nuevo nombre de carpeta"
+
+msgid "No files in here"
+msgstr "No hay archivos aquí"
+
+msgid "No files matching your filter were found."
+msgstr "No se encontraron archivos que coincidiesen con su filtro"
+
+msgid "No matching files"
+msgstr "No hay archivos coincidentes"
+
+msgid "Recent"
+msgstr "Reciente"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Seleccionar todas las entradas"
+
+msgid "Select entry"
+msgstr "Seleccionar entrada"
+
+msgid "Select the row for {nodename}"
+msgstr "Seleccione la fila para {nodename}"
+
+msgid "Size"
+msgstr "Tamaño"
+
 msgid "Undo"
 msgstr "Deshacer"
+
+msgid "unknown"
+msgstr "Desconocido"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "¡Cargue algún contenido o sincronice con sus dispositivos!"

--- a/l10n/es_419.pot
+++ b/l10n/es_419.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Latin America) (https://app.transifex.com/nextcloud/teams/64236/es_419/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Latin America) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_419/)\n"
 "Language: es_419\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_AR.pot
+++ b/l10n/es_AR.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Spanish (Argentina) (https://app.transifex.com/nextcloud/teams/64236/es_AR/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Argentina) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_AR/)\n"
 "Language: es_AR\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Deshacer"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/es_CL.pot
+++ b/l10n/es_CL.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Chile) (https://app.transifex.com/nextcloud/teams/64236/es_CL/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Chile) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_CL/)\n"
 "Language: es_CL\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_CO.pot
+++ b/l10n/es_CO.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Colombia) (https://app.transifex.com/nextcloud/teams/64236/es_CO/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Colombia) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_CO/)\n"
 "Language: es_CO\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_CR.pot
+++ b/l10n/es_CR.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Costa Rica) (https://app.transifex.com/nextcloud/teams/64236/es_CR/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Costa Rica) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_CR/)\n"
 "Language: es_CR\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_DO.pot
+++ b/l10n/es_DO.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Dominican Republic) (https://app.transifex.com/nextcloud/teams/64236/es_DO/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Dominican Republic) (https://app.transifex.com/"
+"nextcloud/teams/64236/es_DO/)\n"
 "Language: es_DO\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_EC.pot
+++ b/l10n/es_EC.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Ecuador) (https://app.transifex.com/nextcloud/teams/64236/es_EC/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Ecuador) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_EC/)\n"
 "Language: es_EC\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_GT.pot
+++ b/l10n/es_GT.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Guatemala) (https://app.transifex.com/nextcloud/teams/64236/es_GT/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Guatemala) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_GT/)\n"
 "Language: es_GT\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_HN.pot
+++ b/l10n/es_HN.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Honduras) (https://app.transifex.com/nextcloud/teams/64236/es_HN/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Honduras) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_HN/)\n"
 "Language: es_HN\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_MX.pot
+++ b/l10n/es_MX.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Spanish (Mexico) (https://app.transifex.com/nextcloud/teams/64236/es_MX/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Mexico) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_MX/)\n"
 "Language: es_MX\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Deshacer"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/es_NI.pot
+++ b/l10n/es_NI.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Nicaragua) (https://app.transifex.com/nextcloud/teams/64236/es_NI/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Nicaragua) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_NI/)\n"
 "Language: es_NI\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_PA.pot
+++ b/l10n/es_PA.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Panama) (https://app.transifex.com/nextcloud/teams/64236/es_PA/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Panama) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_PA/)\n"
 "Language: es_PA\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_PE.pot
+++ b/l10n/es_PE.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Peru) (https://app.transifex.com/nextcloud/teams/64236/es_PE/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Peru) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_PE/)\n"
 "Language: es_PE\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_PR.pot
+++ b/l10n/es_PR.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Puerto Rico) (https://app.transifex.com/nextcloud/teams/64236/es_PR/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Puerto Rico) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_PR/)\n"
 "Language: es_PR\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_PY.pot
+++ b/l10n/es_PY.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Paraguay) (https://app.transifex.com/nextcloud/teams/64236/es_PY/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Paraguay) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_PY/)\n"
 "Language: es_PY\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_SV.pot
+++ b/l10n/es_SV.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (El Salvador) (https://app.transifex.com/nextcloud/teams/64236/es_SV/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (El Salvador) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_SV/)\n"
 "Language: es_SV\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/es_UY.pot
+++ b/l10n/es_UY.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Spanish (Uruguay) (https://app.transifex.com/nextcloud/teams/64236/es_UY/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Spanish (Uruguay) (https://app.transifex.com/nextcloud/"
+"teams/64236/es_UY/)\n"
 "Language: es_UY\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/et_EE.pot
+++ b/l10n/et_EE.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Estonian (Estonia) (https://app.transifex.com/nextcloud/teams/64236/et_EE/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Estonian (Estonia) (https://app.transifex.com/nextcloud/"
+"teams/64236/et_EE/)\n"
 "Language: et_EE\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/eu.pot
+++ b/l10n/eu.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Basque (https://app.transifex.com/nextcloud/teams/64236/eu/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: eu\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Desegin"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/fa.pot
+++ b/l10n/fa.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Persian (https://app.transifex.com/nextcloud/teams/64236/fa/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Persian (https://app.transifex.com/nextcloud/teams/64236/"
+"fa/)\n"
 "Language: fa\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "بازگردانی"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/fi_FI.pot
+++ b/l10n/fi_FI.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Finnish (Finland) (https://app.transifex.com/nextcloud/teams/64236/fi_FI/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Finnish (Finland) (https://app.transifex.com/nextcloud/"
+"teams/64236/fi_FI/)\n"
 "Language: fi_FI\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Kumoa"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/fo.pot
+++ b/l10n/fo.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Faroese (https://app.transifex.com/nextcloud/teams/64236/fo/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Faroese (https://app.transifex.com/nextcloud/teams/64236/"
+"fo/)\n"
 "Language: fo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/fr.pot
+++ b/l10n/fr.pot
@@ -1,15 +1,140 @@
-# 
+#
 # Translators:
-# Ldm Public <ldmpub@gmail.com>, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Rémi LEBLOND, 2023
+# Mordecai, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Ldm Public <ldmpub@gmail.com>, 2023\n"
+"Last-Translator: Mordecai, 2023\n"
 "Language-Team: French (https://app.transifex.com/nextcloud/teams/64236/fr/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Tous les fichiers"
+
+msgid "Choose"
+msgstr "Choisir"
+
+msgid "Choose {file}"
+msgstr "Choisir {file}"
+
+msgid "Copy"
+msgstr "Copier"
+
+msgid "Copy to {target}"
+msgstr "Copier vers {target}"
+
+msgid "Could not create the new folder"
+msgstr "Impossible de créer le nouveau répertoire"
+
+msgid "Create directory"
+msgstr "Créer un répertoire"
+
+msgid "Current view selector"
+msgstr "Sélecteur de vue courante"
+
+msgid "Favorites"
+msgstr "Favoris"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "Sections du sélecteur de fichiers"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Les fichiers et répertoires marqués en favoris apparaîtront ici."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Les fichiers et répertoires modifiés récemment apparaîtront ici."
+
+msgid "Filter file list"
+msgstr "Liste de filtre de fichiers"
+
+msgid "Home"
+msgstr "Accueil"
+
+msgid "MIME type {mime}"
+msgstr "Type MIME {mime}"
+
+msgid "Modified"
+msgstr "Modifié"
+
+msgid "Move"
+msgstr "Déplacer"
+
+msgid "Move to {target}"
+msgstr "Déplacer vers {target}"
+
+msgid "Name"
+msgstr "Nom"
+
+msgid "New"
+msgstr "Nouveau"
+
+msgid "New folder"
+msgstr "Nouveau répertoire"
+
+msgid "New folder name"
+msgstr "Nom du nouveau répertoire"
+
+msgid "No files in here"
+msgstr "Aucun fichier ici"
+
+msgid "No files matching your filter were found."
+msgstr "Aucun fichier trouvé correspondant à votre filtre."
+
+msgid "No matching files"
+msgstr "Aucun fichier trouvé"
+
+msgid "Recent"
+msgstr "Récents"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Tous sélectionner"
+
+msgid "Select entry"
+msgstr "Sélectionner une entrée"
+
+msgid "Select the row for {nodename}"
+msgstr "Sélectionner l'enregistrement pour {nodename}"
+
+msgid "Size"
+msgstr "Taille"
+
 msgid "Undo"
 msgstr "Rétablir"
+
+msgid "unknown"
+msgstr "inconnu"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Charger du contenu ou synchroniser avec vos équipements !"
+

--- a/l10n/gd.pot
+++ b/l10n/gd.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Gaelic, Scottish (https://app.transifex.com/nextcloud/teams/64236/gd/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Gaelic, Scottish (https://app.transifex.com/nextcloud/"
+"teams/64236/gd/)\n"
 "Language: gd\n"
-"Plural-Forms: nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : "
+"(n > 2 && n < 20) ? 2 : 3;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/gl.pot
+++ b/l10n/gl.pot
@@ -1,15 +1,139 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Miguel Anxo Bouzada <mbouzada@gmail.com>, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Galician (https://app.transifex.com/nextcloud/teams/64236/gl/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Miguel Anxo Bouzada <mbouzada@gmail.com>, 2023\n"
+"Language-Team: Galician (https://app.transifex.com/nextcloud/teams/64236/"
+"gl/)\n"
 "Language: gl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Todos os ficheiros"
+
+msgid "Choose"
+msgstr "Escoller"
+
+msgid "Choose {file}"
+msgstr "Escoller {file}"
+
+msgid "Copy"
+msgstr "Copiar"
+
+msgid "Copy to {target}"
+msgstr "Copiar en  {target}"
+
+msgid "Could not create the new folder"
+msgstr "Non foi posíbel crear o novo cartafol"
+
+msgid "Create directory"
+msgstr "Crear un directorio"
+
+msgid "Current view selector"
+msgstr "Selector de vista actual"
+
+msgid "Favorites"
+msgstr "Favoritos"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "Seccións do selector de ficheiros"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Os ficheiros e cartafoles que marque como favoritos aparecerán aquí."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Os ficheiros e cartafoles que modificou recentemente aparecerán aquí."
+
+msgid "Filter file list"
+msgstr "Filtrar a lista de ficheiros"
+
+msgid "Home"
+msgstr "Inicio"
+
+msgid "MIME type {mime}"
+msgstr "Tipo MIME {mime}"
+
+msgid "Modified"
+msgstr "Modificado"
+
+msgid "Move"
+msgstr "Mover"
+
+msgid "Move to {target}"
+msgstr "Mover cara a {target}"
+
+msgid "Name"
+msgstr "Nome"
+
+msgid "New"
+msgstr "Novo"
+
+msgid "New folder"
+msgstr "Novo cartafol"
+
+msgid "New folder name"
+msgstr "Novo nome do cartafol"
+
+msgid "No files in here"
+msgstr "Aquí non hai ficheiros"
+
+msgid "No files matching your filter were found."
+msgstr "Non se atopou ningún ficheiro que coincida co filtro."
+
+msgid "No matching files"
+msgstr "Non hai ficheiros coincidentes"
+
+msgid "Recent"
+msgstr "Recente"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Seleccionar todas as entradas"
+
+msgid "Select entry"
+msgstr "Seleccionar a entrada"
+
+msgid "Select the row for {nodename}"
+msgstr "Seleccionar a fila para {nodename}"
+
+msgid "Size"
+msgstr "Tamaño"
+
 msgid "Undo"
 msgstr "Desfacer"
+
+msgid "unknown"
+msgstr "descoñecido"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Enviar algún contido ou sincronizalo cos seus dispositivos!"
+

--- a/l10n/he.pot
+++ b/l10n/he.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Hebrew (https://app.transifex.com/nextcloud/teams/64236/he/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: he\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % 1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
+"1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "ביטול"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/hi_IN.pot
+++ b/l10n/hi_IN.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Hindi (India) (https://app.transifex.com/nextcloud/teams/64236/hi_IN/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Hindi (India) (https://app.transifex.com/nextcloud/"
+"teams/64236/hi_IN/)\n"
 "Language: hi_IN\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/hr.pot
+++ b/l10n/hr.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Croatian (https://app.transifex.com/nextcloud/teams/64236/hr/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Croatian (https://app.transifex.com/nextcloud/teams/64236/"
+"hr/)\n"
 "Language: hr\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/hsb.pot
+++ b/l10n/hsb.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Upper Sorbian (https://app.transifex.com/nextcloud/teams/64236/hsb/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Upper Sorbian (https://app.transifex.com/nextcloud/"
+"teams/64236/hsb/)\n"
 "Language: hsb\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/hu_HU.pot
+++ b/l10n/hu_HU.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Hungarian (Hungary) (https://app.transifex.com/nextcloud/teams/64236/hu_HU/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Hungarian (Hungary) (https://app.transifex.com/nextcloud/"
+"teams/64236/hu_HU/)\n"
 "Language: hu_HU\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Visszavonás"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/hy.pot
+++ b/l10n/hy.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Armenian (https://app.transifex.com/nextcloud/teams/64236/hy/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Armenian (https://app.transifex.com/nextcloud/teams/64236/"
+"hy/)\n"
 "Language: hy\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/ia.pot
+++ b/l10n/ia.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Interlingua (https://app.transifex.com/nextcloud/teams/64236/ia/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Interlingua (https://app.transifex.com/nextcloud/teams/64236/"
+"ia/)\n"
 "Language: ia\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/id.pot
+++ b/l10n/id.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Indonesian (https://app.transifex.com/nextcloud/teams/64236/id/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Indonesian (https://app.transifex.com/nextcloud/teams/64236/"
+"id/)\n"
 "Language: id\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Tidak jadi"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ig.pot
+++ b/l10n/ig.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Igbo (https://app.transifex.com/nextcloud/teams/64236/ig/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: ig\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/is.pot
+++ b/l10n/is.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Icelandic (https://app.transifex.com/nextcloud/teams/64236/is/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Icelandic (https://app.transifex.com/nextcloud/teams/64236/"
+"is/)\n"
 "Language: is\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Afturkalla"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/it.pot
+++ b/l10n/it.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Italian (https://app.transifex.com/nextcloud/teams/64236/it/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Italian (https://app.transifex.com/nextcloud/teams/64236/"
+"it/)\n"
 "Language: it\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Annulla"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ja_JP.pot
+++ b/l10n/ja_JP.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Japanese (Japan) (https://app.transifex.com/nextcloud/teams/64236/ja_JP/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Japanese (Japan) (https://app.transifex.com/nextcloud/"
+"teams/64236/ja_JP/)\n"
 "Language: ja_JP\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "元に戻す"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ka.pot
+++ b/l10n/ka.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Georgian (https://app.transifex.com/nextcloud/teams/64236/ka/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Georgian (https://app.transifex.com/nextcloud/teams/64236/"
+"ka/)\n"
 "Language: ka\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/ka_GE.pot
+++ b/l10n/ka_GE.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Georgian (Georgia) (https://app.transifex.com/nextcloud/teams/64236/ka_GE/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Georgian (Georgia) (https://app.transifex.com/nextcloud/"
+"teams/64236/ka_GE/)\n"
 "Language: ka_GE\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/kab.pot
+++ b/l10n/kab.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Kabyle (https://app.transifex.com/nextcloud/teams/64236/kab/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Kabyle (https://app.transifex.com/nextcloud/teams/64236/"
+"kab/)\n"
 "Language: kab\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Sefsex"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/kk.pot
+++ b/l10n/kk.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Kazakh (https://app.transifex.com/nextcloud/teams/64236/kk/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: kk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/km.pot
+++ b/l10n/km.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Khmer (https://app.transifex.com/nextcloud/teams/64236/km/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: km\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/kn.pot
+++ b/l10n/kn.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Kannada (https://app.transifex.com/nextcloud/teams/64236/kn/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Kannada (https://app.transifex.com/nextcloud/teams/64236/"
+"kn/)\n"
 "Language: kn\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/ko.pot
+++ b/l10n/ko.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Korean (https://app.transifex.com/nextcloud/teams/64236/ko/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "되돌리기"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/la.pot
+++ b/l10n/la.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Latin (https://app.transifex.com/nextcloud/teams/64236/la/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: la\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/lb.pot
+++ b/l10n/lb.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Luxembourgish (https://app.transifex.com/nextcloud/teams/64236/lb/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Luxembourgish (https://app.transifex.com/nextcloud/"
+"teams/64236/lb/)\n"
 "Language: lb\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/lo.pot
+++ b/l10n/lo.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Lao (https://app.transifex.com/nextcloud/teams/64236/lo/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: lo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/lt_LT.pot
+++ b/l10n/lt_LT.pot
@@ -1,15 +1,139 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Lithuanian (Lithuania) (https://app.transifex.com/nextcloud/teams/64236/lt_LT/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Lithuanian (Lithuania) (https://app.transifex.com/nextcloud/"
+"teams/64236/lt_LT/)\n"
 "Language: lt_LT\n"
-"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < 11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? 1 : n % 1 != 0 ? 2: 3);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
+"11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
+"1 : n % 1 != 0 ? 2: 3);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Atšaukti"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/lv.pot
+++ b/l10n/lv.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Latvian (https://app.transifex.com/nextcloud/teams/64236/lv/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Latvian (https://app.transifex.com/nextcloud/teams/64236/"
+"lv/)\n"
 "Language: lv\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/mk.pot
+++ b/l10n/mk.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Macedonian (https://app.transifex.com/nextcloud/teams/64236/mk/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Macedonian (https://app.transifex.com/nextcloud/teams/64236/"
+"mk/)\n"
 "Language: mk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Врати"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/mn.pot
+++ b/l10n/mn.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Mongolian (https://app.transifex.com/nextcloud/teams/64236/mn/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Mongolian (https://app.transifex.com/nextcloud/teams/64236/"
+"mn/)\n"
 "Language: mn\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Буцаах"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/mr.pot
+++ b/l10n/mr.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Marathi (https://app.transifex.com/nextcloud/teams/64236/mr/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Marathi (https://app.transifex.com/nextcloud/teams/64236/"
+"mr/)\n"
 "Language: mr\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "पूर्ववत करा"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ms_MY.pot
+++ b/l10n/ms_MY.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Malay (Malaysia) (https://app.transifex.com/nextcloud/teams/64236/ms_MY/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Malay (Malaysia) (https://app.transifex.com/nextcloud/"
+"teams/64236/ms_MY/)\n"
 "Language: ms_MY\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/my.pot
+++ b/l10n/my.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Burmese (https://app.transifex.com/nextcloud/teams/64236/my/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Burmese (https://app.transifex.com/nextcloud/teams/64236/"
+"my/)\n"
 "Language: my\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "နဂိုအတိုင်းပြန်ထားရန်"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/nb_NO.pot
+++ b/l10n/nb_NO.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Norwegian Bokmål (Norway) (https://app.transifex.com/nextcloud/teams/64236/nb_NO/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Norwegian Bokmål (Norway) (https://app.transifex.com/"
+"nextcloud/teams/64236/nb_NO/)\n"
 "Language: nb_NO\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Angre"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ne.pot
+++ b/l10n/ne.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Nepali (https://app.transifex.com/nextcloud/teams/64236/ne/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: ne\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/nl.pot
+++ b/l10n/nl.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Dutch (https://app.transifex.com/nextcloud/teams/64236/nl/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: nl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Ongedaan maken"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/nn_NO.pot
+++ b/l10n/nn_NO.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Norwegian Nynorsk (Norway) (https://app.transifex.com/nextcloud/teams/64236/nn_NO/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Norwegian Nynorsk (Norway) (https://app.transifex.com/"
+"nextcloud/teams/64236/nn_NO/)\n"
 "Language: nn_NO\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/oc.pot
+++ b/l10n/oc.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Occitan (post 1500) (https://app.transifex.com/nextcloud/teams/64236/oc/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Occitan (post 1500) (https://app.transifex.com/nextcloud/"
+"teams/64236/oc/)\n"
 "Language: oc\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Anullar"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/pl.pot
+++ b/l10n/pl.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Polish (https://app.transifex.com/nextcloud/teams/64236/pl/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && "
+"(n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && "
+"n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Cofnij"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ps.pot
+++ b/l10n/ps.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Pashto (https://app.transifex.com/nextcloud/teams/64236/ps/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: ps\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/pt_BR.pot
+++ b/l10n/pt_BR.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Portuguese (Brazil) (https://app.transifex.com/nextcloud/teams/64236/pt_BR/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Portuguese (Brazil) (https://app.transifex.com/nextcloud/"
+"teams/64236/pt_BR/)\n"
 "Language: pt_BR\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Desfazer"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/pt_PT.pot
+++ b/l10n/pt_PT.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Portuguese (Portugal) (https://app.transifex.com/nextcloud/teams/64236/pt_PT/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Portuguese (Portugal) (https://app.transifex.com/nextcloud/"
+"teams/64236/pt_PT/)\n"
 "Language: pt_PT\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Anular"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ro.pot
+++ b/l10n/ro.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Romanian (https://app.transifex.com/nextcloud/teams/64236/ro/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Romanian (https://app.transifex.com/nextcloud/teams/64236/"
+"ro/)\n"
 "Language: ro\n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
+"2:1));\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Anulează"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ru.pot
+++ b/l10n/ru.pot
@@ -1,15 +1,142 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Max Smith <sevinfolds@gmail.com>, 2023
+# ashed <craysy@gmail.com>, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Russian (https://app.transifex.com/nextcloud/teams/64236/ru/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: ashed <craysy@gmail.com>, 2023\n"
+"Language-Team: Russian (https://app.transifex.com/nextcloud/teams/64236/"
+"ru/)\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Все файлы"
+
+msgid "Choose"
+msgstr "Выбрать"
+
+msgid "Choose {file}"
+msgstr "Выбрать {file}"
+
+msgid "Copy"
+msgstr "Копировать"
+
+msgid "Copy to {target}"
+msgstr "Скопировать в {target}"
+
+msgid "Could not create the new folder"
+msgstr "Не удалось создать новую папку"
+
+msgid "Create directory"
+msgstr "Создать каталог"
+
+msgid "Current view selector"
+msgstr "Переключатель текущего вида"
+
+msgid "Favorites"
+msgstr "Избранное"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "Разделы для выбора файлов"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Здесь появятся файлы и папки, которые вы пометили как избранные."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Здесь будут отображаться файлы и папки, которые вы недавно изменили."
+
+msgid "Filter file list"
+msgstr "Фильтровать список файлов"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "MIME type {mime}"
+msgstr "MIME тип {mime}"
+
+msgid "Modified"
+msgstr "Модифицированный"
+
+msgid "Move"
+msgstr "Переместить"
+
+msgid "Move to {target}"
+msgstr "Перейти к {target}"
+
+msgid "Name"
+msgstr "Имя"
+
+msgid "New"
+msgstr "Новый"
+
+msgid "New folder"
+msgstr "Новая папка"
+
+msgid "New folder name"
+msgstr "Новое имя папки"
+
+msgid "No files in here"
+msgstr "Здесь нет файлов"
+
+msgid "No files matching your filter were found."
+msgstr "Файлы, соответствующие вашему фильтру, не найдены."
+
+msgid "No matching files"
+msgstr "Нет подходящих файлов"
+
+msgid "Recent"
+msgstr "Недавний"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Выбрать все записи"
+
+msgid "Select entry"
+msgstr "Выберите запись"
+
+msgid "Select the row for {nodename}"
+msgstr "Выберите строку для {nodename}"
+
+msgid "Size"
+msgstr "Размер"
+
 msgid "Undo"
 msgstr "Отменить"
+
+msgid "unknown"
+msgstr "неизвестный"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Загрузите контент или синхронизируйте его со своими устройствами!"
+

--- a/l10n/sc.pot
+++ b/l10n/sc.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Sardinian (https://app.transifex.com/nextcloud/teams/64236/sc/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Sardinian (https://app.transifex.com/nextcloud/teams/64236/"
+"sc/)\n"
 "Language: sc\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/si.pot
+++ b/l10n/si.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Sinhala (https://app.transifex.com/nextcloud/teams/64236/si/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Sinhala (https://app.transifex.com/nextcloud/teams/64236/"
+"si/)\n"
 "Language: si\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "පෙරසේ"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/sk_SK.pot
+++ b/l10n/sk_SK.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Slovak (Slovakia) (https://app.transifex.com/nextcloud/teams/64236/sk_SK/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Slovak (Slovakia) (https://app.transifex.com/nextcloud/"
+"teams/64236/sk_SK/)\n"
 "Language: sk_SK\n"
-"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n >= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n "
+">= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Späť"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/sl.pot
+++ b/l10n/sl.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Slovenian (https://app.transifex.com/nextcloud/teams/64236/sl/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Slovenian (https://app.transifex.com/nextcloud/teams/64236/"
+"sl/)\n"
 "Language: sl\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Razveljavi"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/sq.pot
+++ b/l10n/sq.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Albanian (https://app.transifex.com/nextcloud/teams/64236/sq/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Albanian (https://app.transifex.com/nextcloud/teams/64236/"
+"sq/)\n"
 "Language: sq\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/sr.pot
+++ b/l10n/sr.pot
@@ -1,15 +1,140 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Иван Пешић, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Serbian (https://app.transifex.com/nextcloud/teams/64236/sr/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Иван Пешић, 2023\n"
+"Language-Team: Serbian (https://app.transifex.com/nextcloud/teams/64236/"
+"sr/)\n"
 "Language: sr\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Сви фајлови"
+
+msgid "Choose"
+msgstr "Изаберите"
+
+msgid "Choose {file}"
+msgstr "Изаберите {file}"
+
+msgid "Copy"
+msgstr "Копирај"
+
+msgid "Copy to {target}"
+msgstr "Копирај у {target}"
+
+msgid "Could not create the new folder"
+msgstr "Није могао да се креира нови фолдер"
+
+msgid "Create directory"
+msgstr "Креирај директоријум"
+
+msgid "Current view selector"
+msgstr "Бирач тренутног приказа"
+
+msgid "Favorites"
+msgstr "Омиљено"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "Одељци бирача фајлова"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Овде ће се појавити фајлови и фолдери које сте означили као омиљене."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Овде ће се појавити фајлови и фолдери који се се недавно изменили."
+
+msgid "Filter file list"
+msgstr "Фитрирање листе фајлова"
+
+msgid "Home"
+msgstr "Почетак"
+
+msgid "MIME type {mime}"
+msgstr "MIME тип {mime}"
+
+msgid "Modified"
+msgstr "Измењено"
+
+msgid "Move"
+msgstr "Премести"
+
+msgid "Move to {target}"
+msgstr "Премести у {target}"
+
+msgid "Name"
+msgstr "Име"
+
+msgid "New"
+msgstr "Ново"
+
+msgid "New folder"
+msgstr "Нови фолдер"
+
+msgid "New folder name"
+msgstr "Име новог фолдера"
+
+msgid "No files in here"
+msgstr "Овде нема фајлова"
+
+msgid "No files matching your filter were found."
+msgstr "Није пронађен ниједан фајл који задовољава ваш филтер."
+
+msgid "No matching files"
+msgstr "Нема таквих фајлова"
+
+msgid "Recent"
+msgstr "Скорашње"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Изаберите све ставке"
+
+msgid "Select entry"
+msgstr "Изаберите ставку"
+
+msgid "Select the row for {nodename}"
+msgstr "Изаберите ред за {nodename}"
+
+msgid "Size"
+msgstr "Величина"
+
 msgid "Undo"
 msgstr "Поништи"
+
+msgid "unknown"
+msgstr "непозната"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Отпремите нешто или синхронизујте са својим уређајима!"
+

--- a/l10n/sr@latin.pot
+++ b/l10n/sr@latin.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Serbian (Latin) (https://app.transifex.com/nextcloud/teams/64236/sr@latin/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Serbian (Latin) (https://app.transifex.com/nextcloud/"
+"teams/64236/sr@latin/)\n"
 "Language: sr@latin\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/sv.pot
+++ b/l10n/sv.pot
@@ -1,15 +1,139 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Magnus Höglund, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Swedish (https://app.transifex.com/nextcloud/teams/64236/sv/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Magnus Höglund, 2023\n"
+"Language-Team: Swedish (https://app.transifex.com/nextcloud/teams/64236/"
+"sv/)\n"
 "Language: sv\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Alla filer"
+
+msgid "Choose"
+msgstr "Välj"
+
+msgid "Choose {file}"
+msgstr "Välj {file}"
+
+msgid "Copy"
+msgstr "Kopiera"
+
+msgid "Copy to {target}"
+msgstr "Kopiera till {target}"
+
+msgid "Could not create the new folder"
+msgstr "Kunde inte skapa den nya mappen"
+
+msgid "Create directory"
+msgstr "Skapa katalog"
+
+msgid "Current view selector"
+msgstr "Aktuell vyväljare"
+
+msgid "Favorites"
+msgstr "Favoriter"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "Filepicker-sektioner"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Filer och mappar som du markerar som favorit kommer att visas här."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Filer och mappar som du nyligen ändrat kommer att visas här."
+
+msgid "Filter file list"
+msgstr "Filtrera fillistan"
+
+msgid "Home"
+msgstr "Hem"
+
+msgid "MIME type {mime}"
+msgstr "MIME typ {mime}"
+
+msgid "Modified"
+msgstr "Ändrad"
+
+msgid "Move"
+msgstr "Flytta"
+
+msgid "Move to {target}"
+msgstr "Flytta till {target}"
+
+msgid "Name"
+msgstr "Namn"
+
+msgid "New"
+msgstr "Ny"
+
+msgid "New folder"
+msgstr "Ny mapp"
+
+msgid "New folder name"
+msgstr "Nytt mappnamn"
+
+msgid "No files in here"
+msgstr "Inga filer här"
+
+msgid "No files matching your filter were found."
+msgstr "Inga filer som matchar ditt filter hittades."
+
+msgid "No matching files"
+msgstr "Inga matchande filer"
+
+msgid "Recent"
+msgstr "Nyligen"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Välj alla poster"
+
+msgid "Select entry"
+msgstr "Välj post"
+
+msgid "Select the row for {nodename}"
+msgstr "Välj raden för {nodename}"
+
+msgid "Size"
+msgstr "Storlek"
+
 msgid "Undo"
 msgstr "Ångra"
+
+msgid "unknown"
+msgstr "okänd"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Ladda upp lite innehåll eller synkronisera med dina enheter!"
+

--- a/l10n/sw.pot
+++ b/l10n/sw.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Swahili (https://app.transifex.com/nextcloud/teams/64236/sw/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Swahili (https://app.transifex.com/nextcloud/teams/64236/"
+"sw/)\n"
 "Language: sw\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/ta.pot
+++ b/l10n/ta.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
 "Language-Team: Tamil (https://app.transifex.com/nextcloud/teams/64236/ta/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: ta\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "செயல்தவிர்"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/th_TH.pot
+++ b/l10n/th_TH.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Thai (Thailand) (https://app.transifex.com/nextcloud/teams/64236/th_TH/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Thai (Thailand) (https://app.transifex.com/nextcloud/"
+"teams/64236/th_TH/)\n"
 "Language: th_TH\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "เลิกทำ"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/tk.pot
+++ b/l10n/tk.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Turkmen (https://app.transifex.com/nextcloud/teams/64236/tk/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Turkmen (https://app.transifex.com/nextcloud/teams/64236/"
+"tk/)\n"
 "Language: tk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/tr.pot
+++ b/l10n/tr.pot
@@ -1,15 +1,139 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Kaya Zeren <kayazeren@gmail.com>, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Turkish (https://app.transifex.com/nextcloud/teams/64236/tr/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Kaya Zeren <kayazeren@gmail.com>, 2023\n"
+"Language-Team: Turkish (https://app.transifex.com/nextcloud/teams/64236/"
+"tr/)\n"
 "Language: tr\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "Tüm dosyalar"
+
+msgid "Choose"
+msgstr "Seçin"
+
+msgid "Choose {file}"
+msgstr "{file} seçin"
+
+msgid "Copy"
+msgstr "Kopyala"
+
+msgid "Copy to {target}"
+msgstr "{target} üzerine kopyala"
+
+msgid "Could not create the new folder"
+msgstr "Yeni klasör oluşturulamadı"
+
+msgid "Create directory"
+msgstr "Klasör oluştur"
+
+msgid "Current view selector"
+msgstr "Geçerli görünüm seçici"
+
+msgid "Favorites"
+msgstr "Sık kullanılanlar"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "Dosya seçici bölümleri"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "Sık kullanılan olarak seçtiğiniz dosyalar burada görüntülenir."
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "Son zamanlarda değiştirdiğiniz dosya ve klasörler burada görüntülenir."
+
+msgid "Filter file list"
+msgstr "Dosya listesini süz"
+
+msgid "Home"
+msgstr "Giriş"
+
+msgid "MIME type {mime}"
+msgstr "MIME türü {mime}"
+
+msgid "Modified"
+msgstr "Değiştirilme"
+
+msgid "Move"
+msgstr "Taşı"
+
+msgid "Move to {target}"
+msgstr "{target} üzerine taşı"
+
+msgid "Name"
+msgstr "Ad"
+
+msgid "New"
+msgstr "Yeni"
+
+msgid "New folder"
+msgstr "Yeni klasör"
+
+msgid "New folder name"
+msgstr "Yeni klasör adı"
+
+msgid "No files in here"
+msgstr "Burada herhangi bir dosya yok"
+
+msgid "No files matching your filter were found."
+msgstr "Süzgece uyan bir dosya bulunamadı."
+
+msgid "No matching files"
+msgstr "Eşleşen bir dosya yok"
+
+msgid "Recent"
+msgstr "Son kullanılanlar"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "Tüm kayıtları seç"
+
+msgid "Select entry"
+msgstr "Kaydı seç"
+
+msgid "Select the row for {nodename}"
+msgstr "{nodename} satırını seçin"
+
+msgid "Size"
+msgstr "Boyut"
+
 msgid "Undo"
 msgstr "Geri al"
+
+msgid "unknown"
+msgstr "bilinmiyor"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "Bazı içerikler yükleyin ya da aygıtlarınızla eşitleyin!"
+

--- a/l10n/ug.pot
+++ b/l10n/ug.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Uyghur (https://app.transifex.com/nextcloud/teams/64236/ug/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: ug\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/uk.pot
+++ b/l10n/uk.pot
@@ -1,15 +1,140 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Ukrainian (https://app.transifex.com/nextcloud/teams/64236/uk/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Ukrainian (https://app.transifex.com/nextcloud/teams/64236/"
+"uk/)\n"
 "Language: uk\n"
-"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != "
+"11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % "
+"100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
+"(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Скасувати дію"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/ur_PK.pot
+++ b/l10n/ur_PK.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Urdu (Pakistan) (https://app.transifex.com/nextcloud/teams/64236/ur_PK/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Urdu (Pakistan) (https://app.transifex.com/nextcloud/"
+"teams/64236/ur_PK/)\n"
 "Language: ur_PK\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/uz.pot
+++ b/l10n/uz.pot
@@ -1,15 +1,136 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
 "Language-Team: Uzbek (https://app.transifex.com/nextcloud/teams/64236/uz/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
 "Language: uz\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""

--- a/l10n/vi.pot
+++ b/l10n/vi.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Joas Schilling, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Vietnamese (https://app.transifex.com/nextcloud/teams/64236/vi/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Vietnamese (https://app.transifex.com/nextcloud/teams/64236/"
+"vi/)\n"
 "Language: vi\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
 msgstr "Hoàn tác"
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr ""

--- a/l10n/zh_CN.pot
+++ b/l10n/zh_CN.pot
@@ -1,15 +1,140 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# ken, 2023
+# Eric, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Chinese (China) (https://app.transifex.com/nextcloud/teams/64236/zh_CN/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Eric, 2023\n"
+"Language-Team: Chinese (China) (https://app.transifex.com/nextcloud/"
+"teams/64236/zh_CN/)\n"
 "Language: zh_CN\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "所有文件"
+
+msgid "Choose"
+msgstr "选择"
+
+msgid "Choose {file}"
+msgstr "选择 {file}"
+
+msgid "Copy"
+msgstr "复制"
+
+msgid "Copy to {target}"
+msgstr "复制到 {target}"
+
+msgid "Could not create the new folder"
+msgstr "无法创建新文件夹"
+
+msgid "Create directory"
+msgstr "创建目录"
+
+msgid "Current view selector"
+msgstr "当前视图选择器"
+
+msgid "Favorites"
+msgstr "最爱"
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr "文件选取器选择"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "您标记为最爱的文件与文件夹会显示在这里"
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "您最近修改的文件与文件夹会显示在这里"
+
+msgid "Filter file list"
+msgstr "过滤文件列表"
+
+msgid "Home"
+msgstr "主目录"
+
+msgid "MIME type {mime}"
+msgstr "MIME 类型 {mime}"
+
+msgid "Modified"
+msgstr "已修改"
+
+msgid "Move"
+msgstr "移动"
+
+msgid "Move to {target}"
+msgstr "移动至 {target}"
+
+msgid "Name"
+msgstr "名称"
+
+msgid "New"
+msgstr "新"
+
+msgid "New folder"
+msgstr "新文件夹"
+
+msgid "New folder name"
+msgstr "新文件夹名称"
+
+msgid "No files in here"
+msgstr "此处无文件"
+
+msgid "No files matching your filter were found."
+msgstr "找不到符合您过滤条件的文件"
+
+msgid "No matching files"
+msgstr "无符合的文件"
+
+msgid "Recent"
+msgstr "最近"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "选择所有条目"
+
+msgid "Select entry"
+msgstr "选择条目"
+
+msgid "Select the row for {nodename}"
+msgstr "选择 {nodename} 的列"
+
+msgid "Size"
+msgstr "大小"
+
 msgid "Undo"
 msgstr " 撤消"
+
+msgid "unknown"
+msgstr "未知"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "上传一些项目或与您的设备同步！"
+

--- a/l10n/zh_HK.pot
+++ b/l10n/zh_HK.pot
@@ -1,15 +1,138 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# Café Tango, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Chinese (Hong Kong) (https://app.transifex.com/nextcloud/teams/64236/zh_HK/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: Café Tango, 2023\n"
+"Language-Team: Chinese (Hong Kong) (https://app.transifex.com/nextcloud/"
+"teams/64236/zh_HK/)\n"
 "Language: zh_HK\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr "「{name}」是無效的檔案名稱。"
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr "「{name}」並非允許的檔案類型"
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr "檔案名稱中不允許使用 \"/\"。"
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "所有檔案"
+
+msgid "Choose"
+msgstr "選擇"
+
+msgid "Choose {file}"
+msgstr "選擇 {file}"
+
+msgid "Copy"
+msgstr "複製"
+
+msgid "Copy to {target}"
+msgstr "複製到 {target}"
+
+msgid "Could not create the new folder"
+msgstr "無法建立新資料夾"
+
+msgid "Create directory"
+msgstr "建立目錄"
+
+msgid "Current view selector"
+msgstr "目前檢視選取器"
+
+msgid "Favorites"
+msgstr "最愛"
+
+msgid "File name cannot be empty."
+msgstr "檔案名稱不能為空。"
+
+msgid "Filepicker sections"
+msgstr "檔案挑選器部分"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "您標記為最愛的檔案與資料夾將會顯示在此處。"
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "您最近修改的檔案與資料夾將會顯示在此處。"
+
+msgid "Filter file list"
+msgstr "過濾檔案清單"
+
+msgid "Home"
+msgstr "首頁"
+
+msgid "MIME type {mime}"
+msgstr "MIME 類型 {mime}"
+
+msgid "Modified"
+msgstr "已修改"
+
+msgid "Move"
+msgstr "移動"
+
+msgid "Move to {target}"
+msgstr "移動至 {target}"
+
+msgid "Name"
+msgstr "名稱"
+
+msgid "New"
+msgstr "新"
+
+msgid "New folder"
+msgstr "新資料夾"
+
+msgid "New folder name"
+msgstr "新資料夾名稱"
+
+msgid "No files in here"
+msgstr "此處無檔案"
+
+msgid "No files matching your filter were found."
+msgstr "找不到符合您過濾條件的檔案。"
+
+msgid "No matching files"
+msgstr "無符合的檔案"
+
+msgid "Recent"
+msgstr "最近"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "選取所有條目"
+
+msgid "Select entry"
+msgstr "選取條目"
+
+msgid "Select the row for {nodename}"
+msgstr "選取 {nodename} 的列"
+
+msgid "Size"
+msgstr "大小"
+
 msgid "Undo"
 msgstr "還原"
+
+msgid "unknown"
+msgstr "不詳"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "上傳一些內容或與您的裝置同步"

--- a/l10n/zh_TW.pot
+++ b/l10n/zh_TW.pot
@@ -1,15 +1,139 @@
-# 
+#
 # Translators:
-# Joas Schilling, 2023
-# 
+# John Molakvoæ <skjnldsv@protonmail.com>, 2023
+# 黃柏諺 <s8321414@gmail.com>, 2023
+#
 msgid ""
 msgstr ""
-"Last-Translator: Joas Schilling, 2023\n"
-"Language-Team: Chinese (Taiwan) (https://app.transifex.com/nextcloud/teams/64236/zh_TW/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Last-Translator: 黃柏諺 <s8321414@gmail.com>, 2023\n"
+"Language-Team: Chinese (Taiwan) (https://app.transifex.com/nextcloud/"
+"teams/64236/zh_TW/)\n"
 "Language: zh_TW\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr "「{name}」是無效的檔案名稱。"
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr "「{name}」並非允許的檔案類型"
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr "檔案名稱中不允許使用「/」。"
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr "所有檔案"
+
+msgid "Choose"
+msgstr "選擇"
+
+msgid "Choose {file}"
+msgstr "選擇 {file}"
+
+msgid "Copy"
+msgstr "複製"
+
+msgid "Copy to {target}"
+msgstr "複製到 {target}"
+
+msgid "Could not create the new folder"
+msgstr "無法建立新資料夾"
+
+msgid "Create directory"
+msgstr "建立目錄"
+
+msgid "Current view selector"
+msgstr "目前檢視選取器"
+
+msgid "Favorites"
+msgstr "最愛"
+
+msgid "File name cannot be empty."
+msgstr "檔案名稱不能為空。"
+
+msgid "Filepicker sections"
+msgstr "檔案挑選器選取"
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr "您標記為最愛的檔案與資料夾將會顯示在此處。"
+
+msgid "Files and folders you recently modified will show up here."
+msgstr "您最近修改的檔案與資料夾將會顯示在此處。"
+
+msgid "Filter file list"
+msgstr "過濾檔案清單"
+
+msgid "Home"
+msgstr "家"
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr "已修改"
+
+msgid "Move"
+msgstr "移動"
+
+msgid "Move to {target}"
+msgstr "移動至 {target}"
+
+msgid "Name"
+msgstr "名稱"
+
+msgid "New"
+msgstr "新"
+
+msgid "New folder"
+msgstr "新資料夾"
+
+msgid "New folder name"
+msgstr "新資料夾名稱"
+
+msgid "No files in here"
+msgstr "此處無檔案"
+
+msgid "No files matching your filter were found."
+msgstr "找不到符合您過濾條件的檔案。"
+
+msgid "No matching files"
+msgstr "無符合的檔案"
+
+msgid "Recent"
+msgstr "最近"
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr "選取所有條目"
+
+msgid "Select entry"
+msgstr "選取條目"
+
+msgid "Select the row for {nodename}"
+msgstr "選取 {nodename} 的列"
+
+msgid "Size"
+msgstr "大小"
+
 msgid "Undo"
 msgstr "復原"
+
+msgid "unknown"
+msgstr "未知"
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
+msgstr "上傳一些內容或與您的裝置同步"
+

--- a/l10n/zu_ZA.pot
+++ b/l10n/zu_ZA.pot
@@ -1,15 +1,137 @@
-# 
+#
 # Translators:
 # Transifex Bot <>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Transifex Bot <>, 2023\n"
-"Language-Team: Zulu (South Africa) (https://app.transifex.com/nextcloud/teams/64236/zu_ZA/)\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: Zulu (South Africa) (https://app.transifex.com/nextcloud/"
+"teams/64236/zu_ZA/)\n"
 "Language: zu_ZA\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/toast.ts:223
+msgid "\"{name}\" is an invalid file name."
+msgstr ""
+
+msgid "\"{name}\" is not an allowed filetype"
+msgstr ""
+
+msgid "\"/\" is not allowed inside a file name."
+msgstr ""
+
+msgid "a few seconds ago"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "Choose"
+msgstr ""
+
+msgid "Choose {file}"
+msgstr ""
+
+msgid "Copy"
+msgstr ""
+
+msgid "Copy to {target}"
+msgstr ""
+
+msgid "Could not create the new folder"
+msgstr ""
+
+msgid "Create directory"
+msgstr ""
+
+msgid "Current view selector"
+msgstr ""
+
+msgid "Favorites"
+msgstr ""
+
+msgid "File name cannot be empty."
+msgstr ""
+
+msgid "Filepicker sections"
+msgstr ""
+
+msgid "Files and folders you mark as favorite will show up here."
+msgstr ""
+
+msgid "Files and folders you recently modified will show up here."
+msgstr ""
+
+msgid "Filter file list"
+msgstr ""
+
+msgid "Home"
+msgstr ""
+
+msgid "MIME type {mime}"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Move"
+msgstr ""
+
+msgid "Move to {target}"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "New folder"
+msgstr ""
+
+msgid "New folder name"
+msgstr ""
+
+msgid "No files in here"
+msgstr ""
+
+msgid "No files matching your filter were found."
+msgstr ""
+
+msgid "No matching files"
+msgstr ""
+
+msgid "Recent"
+msgstr ""
+
+#. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+msgid "sec. ago"
+msgstr ""
+
+#. FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+msgid "seconds ago"
+msgstr ""
+
+msgid "Select all entries"
+msgstr ""
+
+msgid "Select entry"
+msgstr ""
+
+msgid "Select the row for {nodename}"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
 msgid "Undo"
+msgstr ""
+
+msgid "unknown"
+msgstr ""
+
+msgid "Unset"
+msgstr ""
+
+msgid "Upload some content or sync with your devices!"
 msgstr ""


### PR DESCRIPTION
Update translations for the filepicker used in NC 27. Transifex only supports one branch -> update from main branch using:

```sh
cp l10n l10n-master
git checkout stable4
pushd l10n
for f in *; do msgmerge -N $f messages.pot | sed '/^#~/d' | sed '/^$/N;/^\n$/D' > a; mv a $f; done
for f in *; do msgmerge -N ../master-l10n/$f $f | sed '/^#~/d' | sed '/^$/N;/^\n$/D' > a; mv a $f; done
popd
```