### PR TITLE
Update `@nextcloud/vue` to stable and release v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v5.0.0](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.0) (2023-11-08)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.0.0-beta.6...v5.0.0)
+
+### :rocket: Enhancement
+* FilePicker: Signal folder creation to files app [\#1095](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1095) ([@susnux](https://github.com/susnux))
+
+### :bug: Fixed bugs
+* fix: Use `NcDialog` instead of custom dialog component now that it is upstreamed [\#1101](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1101) ([@susnux](https://github.com/susnux))
+
+### Changed
+* Updated translations
+* Updated dependencies
+  * Now using stable `@nextcloud/vue` version 8.0.0
+  * Now using stable `@nextcloud/files` version 3.0.0
+
 ## [v5.0.0-beta.6](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.0-beta.6) (2023-10-17)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.0.0-beta.5...v5.0.0-beta.6)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mdi/svg": "^7.3.67",
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/event-bus": "^3.1.0",
-        "@nextcloud/files": "^3.0.0-beta.27",
+        "@nextcloud/files": "^3.0.0",
         "@nextcloud/initial-state": "^2.1.0",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/router": "^2.2.0",
@@ -52,7 +52,7 @@
         "npm": "^9.0.0"
       },
       "peerDependencies": {
-        "@nextcloud/vue": "^8.0.0-beta.10",
+        "@nextcloud/vue": "^8.0.0",
         "vue": "^2.7.15"
       }
     },
@@ -3673,9 +3673,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0-beta.27.tgz",
-      "integrity": "sha512-NEfBT9SzWVwnRoxDItnLYKTyQflPTNXnmJVVmNejJHpKxvLji2h07qkh0PC2M44SDE6j1HHXzyE2FgfDzgOAZw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0.tgz",
+      "integrity": "sha512-zk5oIuVDyk2gWBKCJ+0B1HE3VjhuGnz2iLNbTcbRuTjMYb6aYCAEn1LY0dXbUQG93ehndYJCOdaYri/TaGrlXw==",
       "dependencies": {
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/l10n": "^2.2.0",
@@ -3820,9 +3820,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.0.0-beta.10.tgz",
-      "integrity": "sha512-vyNq8dZE3QkIYOyumT+JX6YkAJYZpLcFdpwIiqeteAyELTAWzprFaPRUuC9yLI/b+HHv8IKeWQ/7nQcKWijUyQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.0.0.tgz",
+      "integrity": "sha512-qzpOfc0iVPAwe1l8xg5SHI3LgYGxWQhjnIFWUU4sit8w7LIq7gjAP/QWSjY1a7Auvh9N40aKBSHR5IJ9BFCJUA==",
       "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -3864,7 +3864,6 @@
         "vue": "^2.7.14",
         "vue-color": "^2.8.1",
         "vue-frag": "^1.4.3",
-        "vue-material-design-icons": "^5.1.2",
         "vue2-datepicker": "^3.11.0"
       },
       "engines": {
@@ -18319,7 +18318,8 @@
     "node_modules/vue-material-design-icons": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.2.0.tgz",
-      "integrity": "sha512-fcdcJHQ9fQw2CAytuLAzWSELcxH138sCdMItVhvmO7Lu9afIgojB/UCWv7XHt/lURsnq/n6O+muM4AQgw8yfig=="
+      "integrity": "sha512-fcdcJHQ9fQw2CAytuLAzWSELcxH138sCdMItVhvmO7Lu9afIgojB/UCWv7XHt/lURsnq/n6O+muM4AQgw8yfig==",
+      "dev": true
     },
     "node_modules/vue-resize": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.0.0-beta.6",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "5.0.0-beta.6",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.3.67",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.0.0-beta.6",
+  "version": "5.0.0",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
     "dist"
   ],
   "peerDependencies": {
-    "@nextcloud/vue": "^8.0.0-beta.10",
+    "@nextcloud/vue": "^8.0.0",
     "vue": "^2.7.15"
   },
   "dependencies": {
     "@mdi/svg": "^7.3.67",
     "@nextcloud/axios": "^2.4.0",
     "@nextcloud/event-bus": "^3.1.0",
-    "@nextcloud/files": "^3.0.0-beta.27",
+    "@nextcloud/files": "^3.0.0",
     "@nextcloud/initial-state": "^2.1.0",
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/router": "^2.2.0",


### PR DESCRIPTION
### :rocket: Enhancement
* FilePicker: Signal folder creation to files app [\#1095](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1095) ([@susnux](https://github.com/susnux))

### :bug: Fixed bugs
* fix: Use `NcDialog` instead of custom dialog component now that it is upstreamed [\#1101](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1101) ([@susnux](https://github.com/susnux))

### Changed
* Updated translations
* Updated dependencies
  * Now using stable `@nextcloud/vue` version 8.0.0
  * Now using stable `@nextcloud/files` version 3.0.0