### PR TITLE
chore: Release 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v5.0.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.1) (2023-11-23)
+## [v5.0.2](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.2) (2023-11-17)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.0.1...v5.0.2)
+
+### :bug: Fixed bugs
+* fix(FilePicker): Listen on `update:open` rather than `closed` event from `NcDialog` [\#1113](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1113) ([@susnux](https://github.com/susnux))
+
+### Changed
+* Updated translations
+* chore(deps): Bump `@nextcloud/vue` from 8.2.0
+
+## [v5.0.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.1) (2023-11-15)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.0.0...v5.0.1)
 
 ### :bug: Fixed bugs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.3.67",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v5.0.2](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.2) (2023-11-17)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.0.1...v5.0.2)

### :bug: Fixed bugs
* fix(FilePicker): Listen on `update:open` rather than `closed` event from `NcDialog` [\#1113](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1113) ([@susnux](https://github.com/susnux))

### Changed
* Updated translations
* chore(deps): Bump `@nextcloud/vue` from 8.2.0