### PR TITLE
fix(FilePicker): `cropImagePreviews` is now provided as a prop in FilePreview

### DIFF
--- a/lib/components/FilePicker/FileListRow.vue
+++ b/lib/components/FilePicker/FileListRow.vue
@@ -56,7 +56,7 @@ const props = defineProps<{
 	/** The current node */
 	node: Node
 	/** Whether the preview should be cropped */
-	cropImagePreviews: Boolean
+	cropImagePreviews: boolean
 }>()
 
 const emit = defineEmits<{

--- a/lib/components/FilePicker/FilePreview.vue
+++ b/lib/components/FilePicker/FilePreview.vue
@@ -25,10 +25,10 @@ const fileListIconStyles = ref(fileListIconStylesModule)
 
 const props = defineProps<{
 	node: Node
-	cropImagePreviews: Boolean
+	cropImagePreviews: boolean
 }>()
 
-const previewURL = computed(() => getPreviewURL(props.node, { cropPreview: cropImagePreviews.value }))
+const previewURL = computed(() => getPreviewURL(props.node, { cropPreview: props.cropImagePreviews }))
 
 const isFile = computed(() => props.node.type === FileType.File)
 const canLoadPreview = ref(false)

--- a/lib/composables/filesSettings.ts
+++ b/lib/composables/filesSettings.ts
@@ -19,12 +19,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import type { ComputedRef, Ref } from 'vue'
+
 import { loadState } from '@nextcloud/initial-state'
-import { computed, ref, type ComputedRef, type Ref } from 'vue'
-import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { toValue } from '@vueuse/core'
-import { onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+
+import axios from '@nextcloud/axios'
 
 interface OCAFilesUserConfig {
 	show_hidden: boolean


### PR DESCRIPTION
* Regression of #1108
* Resolves: https://github.com/nextcloud-libraries/nextcloud-dialogs/issues/1119

We need to use the property instead of the previous available reference for `cropImagePreviews`.