### PR TITLE
fix(FilePicker): On button click also emit the current directory if `allowPickDirectory` is set to true

### DIFF
--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -146,7 +146,7 @@ const dialogButtons = computed(() => {
 		callback: async () => {
 			const nodes = selectedFiles.value.length === 0 && props.allowPickDirectory ? [await getFile(currentPath.value)] : selectedFiles.value as Node[]
 			button.callback(nodes)
-			emit('close', selectedFiles.value as Node[])
+			emit('close', nodes)
 		},
 	} as IFilePickerButton))
 })


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/41414

Basically also add the current directory as selected node if allowed, otherwise the filepicker builder with reject the promise even if you click "move to" button on the file picker when selecting a folder.