### PR TITLE
fix(build): include ?raw data to bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "5.0.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@mdi/svg": "^7.3.67",
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/files": "^3.0.0",
@@ -24,6 +23,7 @@
         "webdav": "^5.3.0"
       },
       "devDependencies": {
+        "@mdi/svg": "^7.3.67",
         "@nextcloud/browserslist-config": "^3.0.0",
         "@nextcloud/eslint-config": "^8.3.0",
         "@nextcloud/stylelint-config": "^2.3.1",
@@ -3322,7 +3322,8 @@
     "node_modules/@mdi/svg": {
       "version": "7.3.67",
       "resolved": "https://registry.npmjs.org/@mdi/svg/-/svg-7.3.67.tgz",
-      "integrity": "sha512-KNr7D8jbu8DEprgRckVywVBkajsGGqocFjOzlekv35UedLjpkMDTkFO8VYnhnLySL0QaPBa568fe8BZsB0TBJQ=="
+      "integrity": "sha512-KNr7D8jbu8DEprgRckVywVBkajsGGqocFjOzlekv35UedLjpkMDTkFO8VYnhnLySL0QaPBa568fe8BZsB0TBJQ==",
+      "dev": true
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.38.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "vue": "^2.7.15"
   },
   "dependencies": {
-    "@mdi/svg": "^7.3.67",
     "@nextcloud/axios": "^2.4.0",
     "@nextcloud/event-bus": "^3.1.0",
     "@nextcloud/files": "^3.0.0",
@@ -69,6 +68,7 @@
     "webdav": "^5.3.0"
   },
   "devDependencies": {
+    "@mdi/svg": "^7.3.67",
     "@nextcloud/browserslist-config": "^3.0.0",
     "@nextcloud/eslint-config": "^8.3.0",
     "@nextcloud/stylelint-config": "^2.3.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,8 +57,13 @@ export default defineConfig((env) => {
 		nodeExternalsOptions: {
 			// for subpath imports like '@nextcloud/l10n/gettext'
 			include: [/^@nextcloud\//],
-			// we should externalize vue SFC dependencies
-			exclude: [/^vue-material-design-icons\//, /\.vue(\?|$)/],
+			exclude: [
+				// we should externalize vue SFC dependencies 
+				/^vue-material-design-icons\//, 
+				/\.vue(\?|$)/, 
+				// and bundle raw data, e.g., raw SVGs
+				/\?raw$/
+			],
 		},
 		// Inject our translations
 		replace: {


### PR DESCRIPTION
Currently, importing raw SVG icons is externalized and used as it is in dist. However, such import is not valid and requires additional bundler configuration. Even when this library doesn't include CSS imports to the bundle.

### Before in `dist`

```js
import IconMove from '@mdi/svg/svg/folder-move.svg?raw'
import IconCopy from '@mdi/svg/svg/folder-multiple.svg?raw'
```

### After

```js
const IconMove = '<svg xmlns="http://www.w3.org/2000/svg" id="mdi-folder-move" viewBox="0 0 24 24"><path d="M14,18V15H10V11H14V8L19,13M20,6H12L10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6Z" /></svg>'
const IconCopy = '<svg xmlns="http://www.w3.org/2000/svg" id="mdi-folder-multiple" viewBox="0 0 24 24"><path d="M22,4H14L12,2H6A2,2 0 0,0 4,4V16A2,2 0 0,0 6,18H22A2,2 0 0,0 24,16V6A2,2 0 0,0 22,4M2,6H0V11H0V20A2,2 0 0,0 2,22H20V20H2V6Z" /></svg>'
```