### PR TITLE
fix(FilePicker): Set default of `path` to undefined to allow using the saved path

### DIFF
--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -113,7 +113,7 @@ const props = withDefaults(defineProps<{
 	filterFn: undefined,
 	mimetypeFilter: () => [],
 	multiselect: true,
-	path: '/',
+	path: undefined,
 })
 
 const emit = defineEmits<{


### PR DESCRIPTION
Bring back the "saved path" or "last path" feature.

The property should default to undefined to the check in the computed property (currentPath) can use the last saved path as a fallback.