### PR TITLE
feat(breadcrumb): added href and stopped event default on a element

### DIFF
--- a/lib/components/FilePicker/FilePickerBreadcrumbs.vue
+++ b/lib/components/FilePicker/FilePickerBreadcrumbs.vue
@@ -3,7 +3,8 @@
 		<template #default>
 			<NcBreadcrumb :name="t('Home')"
 				:title="t('Home')"
-				@click="emit('update:path', '/')">
+				:href="getPath"
+				@click.prevent="emit('update:path', '/')">
 				<template #icon>
 					<IconHome :size="20" />
 				</template>
@@ -12,7 +13,8 @@
 				:key="dir.path"
 				:name="dir.name"
 				:title="dir.path"
-				@click="emit('update:path', dir.path)" />
+				:href="getPath"
+				@click.prevent="emit('update:path', dir.path)" />
 		</template>
 		<template v-if="showMenu" #actions>
 			<NcActions :aria-label="t('Create directory')"
@@ -119,6 +121,11 @@ const pathElements = computed(() => props.path.split('/')
 		path: '/' + elements.slice(0, i + 1).join('/'),
 	})),
 )
+
+/**
+ * Gets the current url path
+ */
+const getPath = computed(() => window.location.pathname)
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## ☑️ For nextcloud/server#42624

## 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/110193237/2ad147d7-874a-4591-84ef-ffbf9f1d5bad)|![firefox_s9J1mvZeTU](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/110193237/0206f70b-31c2-4db4-9415-8f3615889ca5)

## GIF For New Changes
![firefox_tPXw1ltV1S](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/110193237/029df379-e65b-41ee-aed5-0b4928435ae0)

## 🚧 Summary
Added an HREF attribute to the link element. Once this gets merged / challenged / changed, will update the library in nextcloud/server