### PR TITLE
Remove `aria-label` from `<div>`

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -56,9 +56,6 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-msgid "MIME type {mime}"
-msgstr ""
-
 msgid "Modified"
 msgstr ""
 
@@ -105,9 +102,6 @@ msgid "Size"
 msgstr ""
 
 msgid "Undo"
-msgstr ""
-
-msgid "unknown"
 msgstr ""
 
 msgid "Upload some content or sync with your devices!"

--- a/lib/components/FilePicker/FilePreview.vue
+++ b/lib/components/FilePicker/FilePreview.vue
@@ -1,6 +1,5 @@
 <template>
 	<div :style="canLoadPreview ? { backgroundImage: `url(${previewURL})`} : undefined"
-		:aria-label="t('MIME type {mime}', { mime: node.mime || t('unknown') })"
 		:class="fileListIconStyles['file-picker__file-icon']">
 		<template v-if="!canLoadPreview">
 			<IconFile v-if="isFile" :size="20" />


### PR DESCRIPTION
It is not allowed to put `aria-label` not on the interactive elements.

Besides this such text isn't nice for screen reader like: "MIME type httpd/unix-directory", "MIME type image/png", "MIME type text/markdown". Would be much better to have just "folder", "document", "image". Some kind of mapping can be done in future (it is not mandatory).  For now removing wrong attribute: https://github.com/nextcloud/server/issues/42626#issuecomment-1881010301