### PR TITLE
Remove unneeded `tab`, `tablist` and `aria-selected` roles from navigation

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -38,9 +38,6 @@ msgstr ""
 msgid "Favorites"
 msgstr ""
 
-msgid "Filepicker sections"
-msgstr ""
-
 msgid "Files and folders you mark as favorite will show up here."
 msgstr ""
 

--- a/lib/components/FilePicker/FilePickerNavigation.vue
+++ b/lib/components/FilePicker/FilePickerNavigation.vue
@@ -14,14 +14,10 @@
 		</NcTextField>
 		<!-- On non collapsed dialogs show the tablist, otherwise a dropdown is shown -->
 		<ul v-if="!isCollapsed"
-			class="file-picker__side"
-			role="tablist"
-			:aria-label="t('Filepicker sections')">
+			class="file-picker__side">
 			<li v-for="view in allViews" :key="view.id">
-				<NcButton :aria-selected="currentView === view.id"
-					:type="currentView === view.id ? 'primary' : 'tertiary'"
+				<NcButton :type="currentView === view.id ? 'primary' : 'tertiary'"
 					:wide="true"
-					role="tab"
 					@click="$emit('update:currentView', view.id)">
 					<template #icon>
 						<component :is="view.icon" :size="20" />


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/server/issues/42599
* See https://github.com/nextcloud/server/issues/42599#issuecomment-1879050422
* Navigation example: https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html

### 🖼️ Screenshots

🏚️ Before | 🏡 After

No visual changes. Result: no errors through automatically a11y tests.