### PR TITLE
chore: Prepare 4.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v4.2.3](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v4.2.3) (2024-01-19)
+
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v4.2.2...v4.2.3)
+
+### :bug: Fixed bugs
+* fix(FilePicker): Use Node::path for current path fixing an clicking favorite folders [\#1167](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1167) ([susnux](https://github.com/susnux))
+
+### Changed
+* Updated dependencies
+
 ## [v4.2.2](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v4.2.2) (2023-11-02)
 
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v4.2.1...v4.2.2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v4.2.3](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v4.2.3) (2024-01-19)

[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v4.2.2...v4.2.3)

### :bug: Fixed bugs
* fix(FilePicker): Use Node::path for current path fixing an clicking favorite folders [\#1167](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1167) ([susnux](https://github.com/susnux))

### Changed
* Updated dependencies