### PR TITLE
chore: Prepare 5.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v5.1.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.3) (2024-01-26)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.1.0...v5.1.1)
+
+### :bug: Fixed bugs
+* fix(FilePicker): Stop default close event in case of button press [\#1207](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1207) \([susnux](https://github.com/susnux)\)
+* fix(FilePicker): Export `FilePickerClosed` error [\#1198](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1198) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* Updated translations
+* Updated development dependencies
+
 ## [v5.1.0](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.3) (2024-01-19)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.0.3...v5.1.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v5.1.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.0.3) (2024-01-26)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.1.0...v5.1.1)

### :bug: Fixed bugs
* fix(FilePicker): Stop default close event in case of button press [\#1207](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1207) \([susnux](https://github.com/susnux)\)
* fix(FilePicker): Export `FilePickerClosed` error [\#1198](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1198) \([susnux](https://github.com/susnux)\)

### Changed
* Updated translations
* Updated development dependencies