### PR TITLE
fix: Pin nextcloud/files to last resolved version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",
-        "@nextcloud/files": "^3.0.0-beta.14",
+        "@nextcloud/files": "3.0.0-beta.21",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/router": "^2.2.0",
         "@nextcloud/typings": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@mdi/svg": "^7.4.47",
-    "@nextcloud/files": "^3.0.0-beta.14",
+    "@nextcloud/files": "3.0.0-beta.21",
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/router": "^2.2.0",
     "@nextcloud/typings": "^1.7.0",


### PR DESCRIPTION
Pin version to last resolved version according to lockfile https://github.com/nextcloud-libraries/nextcloud-dialogs/blob/6feaaec5b65ca7295cbf8c6ed9c79a80b238f623/package-lock.json#L3417-L3418

Last updated in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/985

- Checked diff of beta.14 -> beta.21 and seems non-breaking for used APIs

Needed for https://github.com/nextcloud/server/pull/43368