### PR TITLE
chore: v4.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v4.2.5](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v4.2.5) (2024-02-06)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v4.2.4...v4.2.5)
+
+### :bug: Fixed bugs
+* fix: Pin nextcloud/files to last resolved version [\#1226](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1226) ([Pytal](https://github.com/Pytal))
+
 ## [v4.2.4](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v4.2.4) (2024-01-30)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v4.2.3...v4.2.4)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v4.2.5](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v4.2.5) (2024-02-06)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v4.2.4...v4.2.5)

### :bug: Fixed bugs
* fix: Pin nextcloud/files to last resolved version [\#1226](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1226) ([Pytal](https://github.com/Pytal))