### PR TITLE
enh: breadcrumbs are now consistant across server

### DIFF
--- a/lib/components/FilePicker/FilePickerBreadcrumbs.vue
+++ b/lib/components/FilePicker/FilePickerBreadcrumbs.vue
@@ -1,7 +1,7 @@
 <template>
 	<NcBreadcrumbs class="file-picker__breadcrumbs">
 		<template #default>
-			<NcBreadcrumb :name="t('Home')"
+			<NcBreadcrumb :name="t('All files')"
 				:title="t('Home')"
 				@click="emit('update:path', '/')">
 				<template #icon>


### PR DESCRIPTION
Coincides with nextcloud/server#43604
Instead of "Home", breadcrumb name is now "All files". Changed this to be more consistent across the server :)

PLACE TO CHANGE: Section that says "Home"
![image](https://github.com/nextcloud-libraries/nextcloud-dialogs/assets/110193237/2390e69b-8a4f-4321-b8d3-7a391a1235f3)