### PR TITLE
fix(FilePicker): Request all default file props (incl. file id)

### DIFF
--- a/lib/composables/dav.ts
+++ b/lib/composables/dav.ts
@@ -33,6 +33,7 @@ import { computed, onMounted, ref, watch } from 'vue'
  *
  * @param currentView Reference to the current files view
  * @param currentPath Reference to the current files path
+ * @param isPublicEndpoint True if the public `public.php` WebDAV endpoint should be used instead of `remote.php`
  */
 export const useDAVFiles = function(
 	currentView: Ref<'files'|'recent'|'favorites'> | ComputedRef<'files'|'recent'|'favorites'>,
@@ -102,6 +103,7 @@ export const useDAVFiles = function(
 
 		const { data } = await client.value.stat(`${rootPath}${path}`, {
 			details: true,
+			data: davGetDefaultPropfind(),
 		}) as ResponseDataDetailed<FileStat>
 		return resultToNode(data)
 	}


### PR DESCRIPTION
* Supersedes https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1284
* Supersedes https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1285
* Resolves https://github.com/nextcloud/server/issues/44482

The propfind was not requesting all needed props, this is fixed by using `davGetDefaultProps` which will then load the file id.