### PR TITLE
chore: Prepare 5.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v5.2.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.2.1) (2024-04-09)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.2.0...v5.2.1)
+
+### Fixed bug
+* fix(FilePicker): Request all default file props (incl. file id) [\#1287](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1287) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* Updated translations
+* Updated development dependencies
+* chore(deps): Bump @nextcloud/files from 3.1.0 to 3.1.1
+* chore(deps): Bump webdav from 5.4.0 to 5.5.0
+
 ## [v5.2.0](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.2.0) (2024-03-06)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.1.2...v5.2.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v5.2.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.2.1) (2024-04-09)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.2.0...v5.2.1)

### Fixed bug
* fix(FilePicker): Request all default file props (incl. file id) [\#1287](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1287) \([susnux](https://github.com/susnux)\)

### Changed
* Updated translations
* Updated development dependencies
* chore(deps): Bump @nextcloud/files from 3.1.0 to 3.1.1
* chore(deps): Bump webdav from 5.4.0 to 5.5.0

