### PR TITLE
chore: v5.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v5.3.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.3.1) (2024-04-16)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.3.0...v5.3.1)
+
+### Fixes
+* fix: Close actions after creating directory and enter it automatically [\#1302](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1302) \([susnux](https://github.com/susnux)\)
+* fix: Fix incorrect directory contents when navigating quickly [\#1299](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1299) \([Pytal](https://github.com/Pytal)\)
+
+### Changed
+* Dependency updates
+
 ## [v5.3.0](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.3.0) (2024-04-10)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.2.1...v5.3.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [v5.3.1](https://github.com/nextcloud-libraries/nextcloud-dialogs/tree/v5.3.1) (2024-04-16)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v5.3.0...v5.3.1)

### Fixes
* fix: Close actions after creating directory and enter it automatically [\#1302](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1302) \([susnux](https://github.com/susnux)\)
* fix: Fix incorrect directory contents when navigating quickly [\#1299](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1299) \([Pytal](https://github.com/Pytal)\)

### Changed
* Dependency updates