### PR TITLE
[stable4] fix(deps): bump @nextcloud/files to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.4.47",
-        "@nextcloud/files": "3.0.0-beta.21",
+        "@nextcloud/files": "3.0.0",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/router": "^2.2.0",
         "@nextcloud/typings": "^1.7.0",
@@ -3161,15 +3161,15 @@
       }
     },
     "node_modules/@nextcloud/auth": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.1.0.tgz",
-      "integrity": "sha512-wf5xQrWQu6fkl3MGegVdyR5mh/EdSQKJByH3m2Url2K2xbML9Y4Y7LAff9jjJAcMt2MkzzJEM463ZBbgTqs0lg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
+      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
       "dependencies": {
-        "@nextcloud/event-bus": "^3.1.0"
+        "@nextcloud/event-bus": "^3.2.0"
       },
       "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/axios": {
@@ -3373,35 +3373,22 @@
       }
     },
     "node_modules/@nextcloud/event-bus": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.1.0.tgz",
-      "integrity": "sha512-purXQsXbhbmpcDsbDuR0i7vwUgOsqnIUa7QAD3lV/UZUkUT94SmxBM5LgQ8iV8TQBWWleEwQHy5kYfHeTGF9wg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.1.tgz",
+      "integrity": "sha512-VBYJspOVk5aZopgZwCUoMKFqcTLCNel2TLvtu0HMPV2gR5ZLPiPAKbkyKkYTh+Sd5QB1gR6l3STTv1gyal0soQ==",
       "dependencies": {
-        "semver": "^7.5.1"
+        "@types/node": "^20.12.12",
+        "semver": "^7.6.2"
       },
       "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@nextcloud/event-bus/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@nextcloud/event-bus/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3409,22 +3396,18 @@
         "node": ">=10"
       }
     },
-    "node_modules/@nextcloud/event-bus/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@nextcloud/files": {
-      "version": "3.0.0-beta.21",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0-beta.21.tgz",
-      "integrity": "sha512-haydsUhF3t7DTUcC48lveztXZA1KMAkn+DRZUwSWu0S0VF4tTjn/+ZM7pqnNBIqOkPMTW9azAU8h6mmENpvd9w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0.tgz",
+      "integrity": "sha512-zk5oIuVDyk2gWBKCJ+0B1HE3VjhuGnz2iLNbTcbRuTjMYb6aYCAEn1LY0dXbUQG93ehndYJCOdaYri/TaGrlXw==",
       "dependencies": {
-        "@nextcloud/auth": "^2.1.0",
+        "@nextcloud/auth": "^2.2.1",
         "@nextcloud/l10n": "^2.2.0",
-        "@nextcloud/logger": "^2.5.0",
-        "@nextcloud/router": "^2.1.2",
+        "@nextcloud/logger": "^2.7.0",
+        "@nextcloud/paths": "^2.1.0",
+        "@nextcloud/router": "^2.2.0",
         "is-svg": "^5.0.0",
-        "webdav": "^5.2.3"
+        "webdav": "^5.3.0"
       },
       "engines": {
         "node": "^20.0.0",
@@ -3471,16 +3454,24 @@
       }
     },
     "node_modules/@nextcloud/logger": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.5.0.tgz",
-      "integrity": "sha512-vJx5YxPyS9/tg3YoqA8CBN7YTZFHfuhMKJIIWFV28phxXqKhGwKVKh+/Ir8ZIPweIM5n8VNT6JOJq1JjGiMg2w==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.7.0.tgz",
+      "integrity": "sha512-DSJg9H1jT2zfr7uoP4tL5hKncyY+LOuxJzLauj0M/f6gnpoXU5WG1Zw8EFPOrRWjkC0ZE+NCqrMnITgdRRpXJQ==",
       "dependencies": {
         "@nextcloud/auth": "^2.0.0",
         "core-js": "^3.6.4"
       },
       "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
+        "node": "^20.0.0",
+        "npm": "^9.0.0"
+      }
+    },
+    "node_modules/@nextcloud/paths": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.1.0.tgz",
+      "integrity": "sha512-8wX0gqwez0bTuAS8A0OEiqbbp0ZsqLr07zSErmS6OYhh9KZcSt/kO6lQV5tnrFqIqJVsxwz4kHUjtZXh6DSf9Q==",
+      "dependencies": {
+        "core-js": "^3.6.4"
       }
     },
     "node_modules/@nextcloud/router": {
@@ -4187,9 +4178,12 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "20.4.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
-      "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ=="
+      "version": "20.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.1.tgz",
+      "integrity": "sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/parse5": {
       "version": "5.0.3",
@@ -15210,6 +15204,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@mdi/svg": "^7.4.47",
-    "@nextcloud/files": "3.0.0-beta.21",
+    "@nextcloud/files": "3.0.0",
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/router": "^2.2.0",
     "@nextcloud/typings": "^1.7.0",


### PR DESCRIPTION
The required `@nextcloud/files` dependency is broken and fixing this inside other apps is hacky because the package lock has to be adjusted manually. It would be nice to release a 4.x.x version with the fixed dependency to make it easier to fix downstream.

Note that simply adding `@nextcloud/files` as a dependency to an app's package.json does not work because it is not a peer of `@nextcloud/dialogs`. Thus, npm will just install both versions separately. 

E.g. in Deck: 
```
@nextcloud/files@3.0.0-beta.21
node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files
  @nextcloud/files@"3.0.0-beta.21" from @nextcloud/dialogs@4.2.7
  node_modules/@nextcloud/dialogs
    @nextcloud/dialogs@"^4.2.2" from the root project

@nextcloud/files@3.2.1
node_modules/@nextcloud/files
  @nextcloud/files@"^3.0.0" from the root project
```

Ref
- https://github.com/nextcloud/deck/issues/5935
- https://github.com/nextcloud/deck/issues/5822
- https://github.com/nextcloud/calendar/issues/6018

Exemplary (hacky) downstream fix at https://github.com/nextcloud/calendar/pull/6035