### PR TITLE
fix: Prevent invalid range for skeleton number

### DIFF
--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -201,7 +201,7 @@ const fileContainer = ref<HTMLDivElement>()
 			}
 		}
 		// container height - 50px table header / row height of 50px
-		skeletonNumber.value = Math.floor((height - 50) / 50)
+		skeletonNumber.value = Math.max(1, Math.floor((height - 50) / 50))
 	})
 	onMounted(() => {
 		window.addEventListener('resize', resize)


### PR DESCRIPTION
Vue can not handle `v-for="index in -1"` so ensure the number is positive.