### PR TITLE
fix(FilePicker): Cleanup DAV handling and properly handle `currentFolder`

### DIFF
--- a/lib/components/FilePicker/FilePicker.vue
+++ b/lib/components/FilePicker/FilePicker.vue
@@ -146,13 +146,19 @@ const isOpen = ref(true)
  * Map buttons to Dialog buttons by wrapping the callback function to pass the selected files
  */
 const dialogButtons = computed(() => {
-	const nodes = selectedFiles.value.length === 0 && props.allowPickDirectory && currentFolder.value ? [currentFolder.value] : selectedFiles.value
+	const nodes = selectedFiles.value.length === 0
+		&& props.allowPickDirectory
+		&& currentFolder.value
+		? [currentFolder.value]
+		: selectedFiles.value
+
 	const buttons = typeof props.buttons === 'function'
 		? props.buttons(nodes, currentPath.value, currentView.value)
 		: props.buttons
 
 	return buttons.map((button) => ({
 		...button,
+		disabled: button.disabled || isLoading.value,
 		callback: () => {
 			// lock default close handling
 			isHandlingCallback = true
@@ -203,9 +209,9 @@ const navigatedPath = ref('')
 watch([navigatedPath], () => {
 	if (props.path === undefined && navigatedPath.value) {
 		window.sessionStorage.setItem('NC.FilePicker.LastPath', navigatedPath.value)
-		// Reset selected files
-		selectedFiles.value = []
 	}
+	// Reset selected files
+	selectedFiles.value = []
 })
 
 /**

--- a/lib/composables/dav.spec.ts
+++ b/lib/composables/dav.spec.ts
@@ -71,7 +71,6 @@ describe('dav composable', () => {
 		expect(Array.isArray(vue.vm.files)).toBe(true)
 		expect(vue.vm.files.length).toBe(0)
 		// functions
-		expect(typeof vue.vm.getFile === 'function').toBe(true)
 		expect(typeof vue.vm.loadFiles === 'function').toBe(true)
 	})
 
@@ -153,23 +152,6 @@ describe('dav composable', () => {
 		expect(client.search).toBeCalledTimes(1)
 	})
 
-	it('getFile works', async () => {
-		const client = {
-			stat: vi.fn((v) => ({ data: { path: v } })),
-			getDirectoryContents: vi.fn(() => ({ data: [] })),
-		}
-		nextcloudFiles.davGetClient.mockImplementation(() => client)
-		nextcloudFiles.davResultToNode.mockImplementation((v) => v)
-
-		const { getFile } = useDAVFiles(ref('files'), ref('/'))
-
-		const node = await getFile('/some/path/file.ext')
-		expect(node).toEqual({ path: `${nextcloudFiles.davRootPath}/some/path/file.ext` })
-		// Check mock usage
-		expect(client.stat).toBeCalledWith(`${nextcloudFiles.davRootPath}/some/path/file.ext`, { details: true })
-		expect(nextcloudFiles.davResultToNode).toBeCalledWith({ path: `${nextcloudFiles.davRootPath}/some/path/file.ext` })
-	})
-
 	it('createDirectory works', async () => {
 		const client = {
 			stat: vi.fn((v) => ({ data: { path: v } })),
@@ -189,11 +171,12 @@ describe('dav composable', () => {
 	it('loadFiles work', async () => {
 		const client = {
 			stat: vi.fn((v) => ({ data: { path: v } })),
-			getDirectoryContents: vi.fn((p, o) => ({ data: [] })),
-			search: vi.fn((p, o) => ({ data: { results: [], truncated: false } })),
+			getDirectoryContents: vi.fn((_p, _o) => ({ data: [] })),
+			search: vi.fn((_p, _o) => ({ data: { results: [], truncated: false } })),
 		}
 		nextcloudFiles.davGetClient.mockImplementationOnce(() => client)
 		nextcloudFiles.davResultToNode.mockImplementationOnce((v) => v)
+		nextcloudFiles.getFavoriteNodes.mockImplementationOnce(() => Promise.resolve([]))
 
 		const view = ref<'files' | 'recent' | 'favorites'>('files')
 		const path = ref('/')
@@ -216,8 +199,8 @@ describe('dav composable', () => {
 	it('request cancelation works', async () => {
 		const client = {
 			stat: vi.fn((v) => ({ data: { path: v } })),
-			getDirectoryContents: vi.fn((p, o) => ({ data: [] })),
-			search: vi.fn((p, o) => ({ data: { results: [], truncated: false } })),
+			getDirectoryContents: vi.fn((_p, _o) => ({ data: [] })),
+			search: vi.fn((_p, _o) => ({ data: { results: [], truncated: false } })),
 		}
 		nextcloudFiles.davGetClient.mockImplementationOnce(() => client)
 		nextcloudFiles.davResultToNode.mockImplementationOnce((v) => v)

--- a/lib/utils/dav.spec.ts
+++ b/lib/utils/dav.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const nextcloudFiles = vi.hoisted(() => ({
+	davResultToNode: vi.fn((v) => v),
+	davGetDefaultPropfind: vi.fn(() => 'propfind content'),
+	davRootPath: '/root/path',
+}))
+vi.mock('@nextcloud/files', () => nextcloudFiles)
+
+describe('DAV utils', () => {
+	beforeEach(() => {
+		vi.resetModules()
+	})
+
+	it('getFile works', async () => {
+		const client = {
+			stat: vi.fn((v) => Promise.resolve({ data: { path: v } })),
+			getDirectoryContents: vi.fn(() => ({ data: [] })),
+		}
+
+		const { getFile } = await import('./dav')
+
+		const node = await getFile(client, '/some/path/file.ext')
+		expect(node).toEqual({ path: `${nextcloudFiles.davRootPath}/some/path/file.ext` })
+		// Check mock usage
+		expect(client.stat).toBeCalledWith(`${nextcloudFiles.davRootPath}/some/path/file.ext`, { details: true, data: 'propfind content' })
+		expect(nextcloudFiles.davResultToNode).toBeCalledWith({ path: `${nextcloudFiles.davRootPath}/some/path/file.ext` })
+	})
+})

--- a/lib/utils/dav.ts
+++ b/lib/utils/dav.ts
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ContentsWithRoot, Node } from '@nextcloud/files'
+import type { FileStat, ResponseDataDetailed, SearchResult, WebDAVClient } from 'webdav'
+
+import { davGetDefaultPropfind, davGetRecentSearch, davResultToNode, davRootPath } from '@nextcloud/files'
+import { CancelablePromise } from 'cancelable-promise'
+import { join } from 'node:path'
+
+/**
+ * Get the recently changed nodes from the last two weeks
+ * @param client The WebDAV client
+ */
+export function getRecentNodes(client: WebDAVClient): CancelablePromise<Node[]> {
+	const controller = new AbortController()
+	// unix timestamp in seconds, two weeks ago
+	const lastTwoWeek = Math.round(Date.now() / 1000) - (60 * 60 * 24 * 14)
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		onCancel(() => controller.abort())
+		try {
+			const { data } = await client.search('/', {
+				signal: controller.signal,
+				details: true,
+				data: davGetRecentSearch(lastTwoWeek),
+			}) as ResponseDataDetailed<SearchResult>
+			const nodes = data.results.map((result: FileStat) => davResultToNode(result))
+			resolve(nodes)
+		} catch (error) {
+			reject(error)
+		}
+	})
+}
+
+/**
+ * Get the directory content
+ * @param client The WebDAV client
+ * @param directoryPath The path to fetch
+ */
+export function getNodes(client: WebDAVClient, directoryPath: string): CancelablePromise<ContentsWithRoot> {
+	const controller = new AbortController()
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		onCancel(() => controller.abort())
+		try {
+			const results = await client.getDirectoryContents(join(davRootPath, directoryPath), {
+				signal: controller.signal,
+				details: true,
+				includeSelf: true,
+				data: davGetDefaultPropfind(),
+			}) as ResponseDataDetailed<FileStat[]>
+			const nodes = results.data.map((result: FileStat) => davResultToNode(result))
+			resolve({
+				contents: nodes.filter(({ path }) => path !== directoryPath),
+				folder: nodes.find(({ path }) => path === directoryPath),
+			})
+		} catch (error) {
+			reject(error)
+		}
+	})
+}
+
+/**
+ * Get information for one file
+ *
+ * @param client The WebDAV client
+ * @param path The path of the file or folder
+ */
+export async function getFile(client: WebDAVClient, path: string) {
+	const { data } = await client.stat(join(davRootPath, path), {
+		details: true,
+		data: davGetDefaultPropfind(),
+	}) as ResponseDataDetailed<FileStat>
+	return davResultToNode(data)
+}


### PR DESCRIPTION

Instead of fetching the directory in a second request we simply do it like the file app and always request the content together with its root. This also allows to remove some functions by refactoring.