### PR TITLE
chore: 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## 6.1.0
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.0.1...v6.1.0)
+
+### Enhancements
+* feat(toast): add loading toast by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1554
+* feat(files): Add encrypted icon for end-to-end encrypted folder by @JuliaKirschenheuter in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1545
+
+### Fixed
+* Fix npm audit by @nextcloud-command in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1502
+
+### Changed
+* Updated translations
+* Updated development dependencies
+
 ## 6.0.1
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.0.0...v6.0.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 6.1.0
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.0.1...v6.1.0)

### Enhancements
* feat(toast): add loading toast by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1554
* feat(files): Add encrypted icon for end-to-end encrypted folder by @JuliaKirschenheuter in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1545

### Fixed
* Fix npm audit by @nextcloud-command in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1502

### Changed
* Updated translations
* Updated development dependencies