### PR TITLE
fix: css output name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 6.1.1
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.1.0...v6.1.1)
+
+### Fixed
+* Fix css name change by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-dialogs/issues/1558
+
 ## 6.1.0
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.0.1...v6.1.0)
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
       "require": "./dist/filepicker.cjs"
     },
     "./style.css": {
-      "import": "./dist/style.css",
-      "require": "./dist/style.css"
+      "import": "./dist/dialogs.css",
+      "require": "./dist/dialogs.css"
     }
   },
   "scripts": {


### PR DESCRIPTION
Regression from https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1532
- [ ] Needs https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1559

## 6.1.1
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.1.0...v6.1.1)

### Fixed
* Fix css name change by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-dialogs/issues/1558