### PR TITLE
chore: 6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## 6.1.1
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.1.0...v6.1.1)
+
+## Fixed
+* fix(toast): loading svg by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1559
+* fixed css output file via @nextcloud/vite-config update
+
+## Changed
+* chore(deps): Bump p-queue from 8.0.1 to 8.1.0
+* chore(deps-dev): Bump @nextcloud/vite-config from 1.5.0 to 1.5.1
+* chore(deps-dev): Bump @vitest/coverage-v8 from 2.1.8 to 3.0.3
+* chore(deps-dev): Bump happy-dom from 16.7.1 to 16.7.2
+* chore(deps-dev): Bump vite from 6.0.7 to 6.0.9
+* chore(deps-dev): Bump vite from 6.0.9 to 6.0.11
+* chore(deps-dev): Bump vitest from 2.1.8 to 3.0.3
+
 ## 6.1.0
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.0.1...v6.1.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",
@@ -13552,15 +13552,6 @@
       "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Nextcloud dialog helpers",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 6.1.1
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.1.0...v6.1.1)

## Fixed
* fix(toast): loading svg by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1559
* fixed css output file via @nextcloud/vite-config update

## Changed
* chore(deps): Bump p-queue from 8.0.1 to 8.1.0
* chore(deps-dev): Bump @nextcloud/vite-config from 1.5.0 to 1.5.1
* chore(deps-dev): Bump @vitest/coverage-v8 from 2.1.8 to 3.0.3
* chore(deps-dev): Bump happy-dom from 16.7.1 to 16.7.2
* chore(deps-dev): Bump vite from 6.0.7 to 6.0.9
* chore(deps-dev): Bump vite from 6.0.9 to 6.0.11
* chore(deps-dev): Bump vitest from 2.1.8 to 3.0.3