### PR TITLE
chore: simplify vitest config and fix some build issues

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,7 +6,7 @@ SPDX-PackageSupplier = "Nextcloud <info@nextcloud.com>"
 SPDX-PackageDownloadLocation = "https://github.com/nextcloud-libraries/nextcloud-dialogs"
 
 [[annotations]]
-path = ["package-lock.json", "package.json", "tsconfig-typedoc.json", "tsconfig.json"]
+path = ["package-lock.json", "package.json", "tsconfig-typedoc.json", "tsconfig.json", "test/tsconfig.json", ".eslintrc.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2019-2024 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"
@@ -18,10 +18,10 @@ SPDX-FileCopyrightText = "2020-2024 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
-path = ".eslintrc.json"
+path = ".env.development"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 Nextcloud GmbH and Nextcloud contributors"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-FileCopyrightText = "2025 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ["styles/close-dark.svg", "styles/close.svg", "styles/loader.svg"]

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "..",
+	},
+	"include": [
+		"..",
+	],
+	"exclude": [
+		"../dist",
+		"../node_modules",
+	]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,7 @@
       { "name": "typescript-plugin-css-modules" }
     ]
   },
-  "exclude": [
-    "node_modules",
-    "dist",
-    "build"
-  ],
+  "include": ["lib"],
   "vueCompilerOptions": {
     "target": 2.7
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@
 import { createLibConfig } from '@nextcloud/vite-config'
 import { readdirSync, readFileSync } from 'fs'
 import { po as poParser } from 'gettext-parser'
-import { defineConfig, type UserConfigFn } from 'vite'
 
 const translations = readdirSync('./l10n')
 	.filter(name => name !== 'messages.pot' && name.endsWith('.pot'))
@@ -21,40 +20,34 @@ const translations = readdirSync('./l10n')
 		}
 	})
 
-export default defineConfig((env) => {
-	return createLibConfig({
-		index: 'lib/index.ts',
-		filepicker: 'lib/filepicker.ts',
-	}, {
-		config: {
-			build: {
-				// Fix for vite config, TODO: remove with next release
-				cssCodeSplit: false,
-			},
+export default createLibConfig({
+	index: 'lib/index.ts',
+	filepicker: 'lib/filepicker.ts',
+}, {
+	config: {
+		build: {
+			// Fix for vite config, TODO: remove with next release
+			cssCodeSplit: false,
 		},
-		// We build for ESM and legacy common js
-		libraryFormats: ['es', 'cjs'],
-		// We want one single output CSS file
-		inlineCSS: false,
-		// Packages that should be externalized or bundled
-		nodeExternalsOptions: {
-			// for subpath imports like '@nextcloud/l10n/gettext'
-			include: [/^@nextcloud\//],
-			exclude: [
-				// we should not rely on external vue SFC dependencies thus bundle all .vue files
-				/^vue-material-design-icons\//,
-				/\.vue(\?|$)/,
-				// and bundle raw data, e.g., raw SVGs
-				/\?raw$/,
-			],
-		},
-		// Inject our translations
-		replace: {
-			__TRANSLATIONS__: JSON.stringify(translations),
-		},
-		// Rollup our type definitions to only publish what it needed
-		DTSPluginOptions: {
-			rollupTypes: env.mode === 'production',
-		},
-	})(env)
-}) as UserConfigFn
+	},
+	// We build for ESM and legacy common js
+	libraryFormats: ['es', 'cjs'],
+	// We want one single output CSS file
+	inlineCSS: false,
+	// Packages that should be externalized or bundled
+	nodeExternalsOptions: {
+		// for subpath imports like '@nextcloud/l10n/gettext'
+		include: [/^@nextcloud\//],
+		exclude: [
+			// we should not rely on external vue SFC dependencies thus bundle all .vue files
+			/^vue-material-design-icons\//,
+			/\.vue(\?|$)/,
+			// and bundle raw data, e.g., raw SVGs
+			/\?raw$/,
+		],
+	},
+	// Inject our translations
+	replace: {
+		__TRANSLATIONS__: JSON.stringify(translations),
+	},
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,42 +2,33 @@
  * SPDX-FileCopyrightText: 2023-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: CC0-1.0
  */
-import type { ConfigEnv } from 'vite'
-import { defineConfig, type ViteUserConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
 import config from './vite.config'
 
-export default defineConfig(async (env: ConfigEnv): Promise<ViteUserConfig> => {
-	const cfg = await config(env)
-
-	return {
-		...cfg,
-
-		// filter node-externals which will interfere with vitest
-		plugins: cfg.plugins!.filter((plugin) => plugin && (!('name' in plugin) || plugin.name !== 'node-externals')),
-
-		// vitest configuration
-		test: {
-			environment: 'happy-dom',
-			coverage: {
-				all: true,
-				provider: 'v8',
-				include: ['lib/**/*.ts', 'lib/*.ts'],
-				exclude: ['lib/**/*.spec.ts'],
-			},
-			css: {
-				modules: {
-					classNameStrategy: 'non-scoped',
-				},
-			},
-			setupFiles: 'test/setup.ts',
-			server: {
-				deps: {
-					inline: [
-						/@nextcloud\/vue/, // Fix unresolvable .css extension for ssr
-						/@nextcloud\/files/, // Fix CommonJS cancelable-promise not supporting named exports
-					],
-				},
+const testConfig = defineConfig({
+	test: {
+		environment: 'happy-dom',
+		coverage: {
+			all: true,
+			provider: 'v8',
+			include: ['lib/**/*.ts', 'lib/*.ts'],
+			exclude: ['lib/**/*.spec.ts'],
+		},
+		css: {
+			modules: {
+				classNameStrategy: 'non-scoped',
 			},
 		},
-	}
+		setupFiles: 'test/setup.ts',
+		server: {
+			deps: {
+				inline: [
+					/@nextcloud\/vue/, // Fix unresolvable .css extension for ssr
+					/@nextcloud\/files/, // Fix CommonJS cancelable-promise not supporting named exports
+				],
+			},
+		},
+	},
 })
+
+export default defineConfig(async (...args) => mergeConfig(await config(...args), testConfig))


### PR DESCRIPTION
Fixed issues:
- When building with `dev` we were not enabling vue-devtools. This is fixed by setting `NODE_ENV=development`.
- The tsconfig rootdir was not aligned with the `includes` section. All included files need to be within the root dir. So we now have one config for production code and one for setup and tests.
- The config option "rollup types" will create independent type, this causes the filepicker module to be incompatible with the index module we exported. Fixed by not rolling up types (note: roll up types only works when there is only a single entry point)