### PR TITLE
chore: deprecate `Dialog.hide`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 The export of the file picker Vue component is deprecated and will be removed in the next version.
 Instead please use the `FilePickerBuilder`.
 
+The `Dialog.hide` method is deprecated.
+Instead only user interaction should close dialogs,
+for this use the promise returned by `Dialog.show` which will resolve if the user answered the dialog and rejected if the user aborted (closed) the dialog.
+
 ## 6.1.1
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.1.0...v6.1.1)
 

--- a/lib/dialogs.ts
+++ b/lib/dialogs.ts
@@ -54,7 +54,7 @@ export class Dialog {
 	 * Spawn and show the dialog - if already open the previous instance will be destroyed
 	 * @return Promise that resolves when the dialog is answered successfully and rejects on close
 	 */
-	show() {
+	async show() {
 		if (this.#dialog) {
 			this.#dialog.$destroy()
 		}
@@ -75,6 +75,8 @@ export class Dialog {
 
 	/**
 	 * Hide and destroy the current dialog instance
+	 *
+	 * @deprecated use the promise of the `show` methods for the user interaction.
 	 */
 	hide() {
 		this.#dialog?.$destroy()


### PR DESCRIPTION
Similar to #1728 

This allows to align with `spawnDialog` from nextcloud vue. The hide method also does not make much sense.
It was only added for legacy reasons with the jQuery UI dialogs where the app code needed to close dialogs even if the user interacted with them.