### PR TITLE
fix: the nc-vue dialogs function module is called `dialog` not `dialogs`

### DIFF
--- a/lib/dialogs.ts
+++ b/lib/dialogs.ts
@@ -6,7 +6,7 @@
 import type { IDialogButton } from './components/types'
 import type Vue from 'vue'
 
-import { spawnDialog } from '@nextcloud/vue/functions/dialogs'
+import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 
 import { DialogSeverity } from './components/types'
 import GenericDialog from './components/GenericDialog.vue'

--- a/lib/filepicker-builder.ts
+++ b/lib/filepicker-builder.ts
@@ -7,7 +7,7 @@ import type { IFilePickerButton, IFilePickerButtonFactory, IFilePickerFilter } f
 import type { Node } from '@nextcloud/files'
 
 import { basename } from 'path'
-import { spawnDialog } from '@nextcloud/vue/functions/dialogs'
+import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { n, t } from './utils/l10n'
 
 import IconMove from '@mdi/svg/svg/folder-move.svg?raw'

--- a/lib/utils/dialogs.ts
+++ b/lib/utils/dialogs.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { spawnDialog as _spawnDialog } from '@nextcloud/vue/functions/dialogs'
+import { spawnDialog as _spawnDialog } from '@nextcloud/vue/functions/dialog'
 
 /**
  * Helper to spawn a Vue dialog without having to mount it from a component

--- a/lib/vue-shims.d.ts
+++ b/lib/vue-shims.d.ts
@@ -12,7 +12,7 @@ declare module '@nextcloud/vue/components/*' {
 	export default Vue
 }
 
-declare module '@nextcloud/vue/functions/dialogs' {
+declare module '@nextcloud/vue/functions/dialog' {
 	import type { Component, AsyncComponent } from 'vue'
 	interface DialogProps {
 		[index: string]: unknown


### PR DESCRIPTION
Regression from https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1681