### PR TITLE
chore: v7.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ For Vue 3 apps nothing changed, meaning the app and this library will share the 
 ### Fixed
 * fix(FilePickerBuilder): correctly return array / plain value depending on multiselect [\#1775](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1775) \([susnux](https://github.com/susnux)\)
 * fix: display guest name validity [\#1836](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1836) \([skjnldsv](https://github.com/skjnldsv)\)
+* fix: return nodes array from smartpicker by @grnd-alt in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1879
+* fix(PublicAuthPrompt): change default notice if identified by @backportbot[bot] in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1880
 
 ### Changed
 * chore: update to ESLint v9 and apply new rules [\#1753](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1753) \([susnux](https://github.com/susnux)\)
@@ -54,6 +56,8 @@ For Vue 3 apps nothing changed, meaning the app and this library will share the 
 * refactor: adjust code to comply with code style (again) [\#1774](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1774) \([susnux](https://github.com/susnux)\)
 * chore!: remove `spawnDialog` in favor of version from `@nextcloud/vue` [\#1783](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1783) \([susnux](https://github.com/susnux)\)
 * refactor: do not use Node internals but @nextcloud/paths package [\#1752](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1752) \([susnux](https://github.com/susnux)\)
+* Updates for project Nextcloud dialogs library by @transifex-integration[bot] 
+* chore(deps): @nextcloud family + various upgrades by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1905
 
 ## [v6.2.0](https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v6.1.1...v6.2.0)
 ### Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "7.0.0-rc.1",
+  "version": "7.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/dialogs",
-      "version": "7.0.0-rc.1",
+      "version": "7.0.0-rc.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/dialogs",
-  "version": "7.0.0-rc.1",
+  "version": "7.0.0-rc.2",
   "description": "Nextcloud dialog helpers",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### 🐛 Fixed bugs
* fix: return nodes array from smartpicker by @grnd-alt in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1879
* fix(PublicAuthPrompt): change default notice if identified by @backportbot[bot] in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1880
### Other Changes
* Updates for project Nextcloud dialogs library by @transifex-integration[bot] 
* chore(deps): @nextcloud family + various upgrades by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1905

## New Contributors
* @grnd-alt made their first contribution in https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/1879

**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-dialogs/compare/v7.0.0-rc.1...v7.0.0-rc.2