### PR TITLE
fix(guestName): limit length to 64 characters

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -100,6 +100,9 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+msgid "Names may be at most 64 characters long."
+msgstr ""
+
 msgid "Names must not be empty."
 msgstr ""
 

--- a/lib/components/PublicAuthPrompt.vue
+++ b/lib/components/PublicAuthPrompt.vue
@@ -196,6 +196,7 @@ function onSubmit() {
 			:placeholder="t('Enter your name')"
 			:required="!cancellable"
 			minlength="2"
+			maxlength="64"
 			name="name" />
 	</NcDialog>
 </template>

--- a/lib/utils/guestNameValidity.spec.ts
+++ b/lib/utils/guestNameValidity.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { getGuestNameValidity } from './guestNameValidity.ts'
+
+vi.mock('@nextcloud/files', () => ({
+	validateFilename: vi.fn(),
+}))
+
+describe('guestNameValidity', () => {
+	it('rejects names that are too long', () => {
+		const tooLong = 'This string is longer than 64 characters and therefore tooo long.'
+		expect(tooLong.length).toBeGreaterThan(64)
+		expect(getGuestNameValidity(tooLong)).toBe('Names may be at most 64 characters long.')
+	})
+
+	it('Accepts long strings in 16 bit chars.', () => {
+		const shortEnough = '人名用漢字 (Jinmeiyō-Kanji) used in names: 丑丞乃之也亀...'
+		expect(shortEnough.length).toBeLessThan(64)
+		expect(getGuestNameValidity(shortEnough)).toBe('')
+	})
+})

--- a/lib/utils/guestNameValidity.ts
+++ b/lib/utils/guestNameValidity.ts
@@ -20,6 +20,10 @@ export function getGuestNameValidity(name: string): string {
 		return t('Names must not start with a dot.')
 	}
 
+	if (name.length > 64) {
+		return t('Names may be at most 64 characters long.')
+	}
+
 	try {
 		validateFilename(name)
 		return ''


### PR DESCRIPTION
This is the same limit we apply to authenticated user display names.

The text app stores guest names in a 64 char database field.

Note that this is counting characters - not bytes.
So languages with multi-byte characters can still use 64 chars in name.
