### PR TITLE
chore: fix node version for dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,8 +58,7 @@
         "vue-material-design-icons": "^5.3.1"
       },
       "engines": {
-        "node": "^20 || ^22",
-        "npm": "^10.0.0"
+        "node": "^20 || ^22 || ^24"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,19 @@
     "vue-material-design-icons": "^5.3.1"
   },
   "engines": {
-    "node": "^20 || ^22",
-    "npm": "^10.0.0"
+    "node": "^20 || ^22 || ^24"
+  },
+  "devEngines": {
+    "packageManager": [
+      {
+        "name": "npm",
+        "version": "^10.5.0",
+        "onFail": "error"
+      }
+    ],
+    "runtime": {
+      "name": "node",
+      "version": "^22.0.0"
+    }
   }
 }


### PR DESCRIPTION
- support LTS Node versions
- use array syntax for dev engines to fix dependabot / corepack