### PR TITLE
fix(dav): Prevent race condition in `useDAVFiles`

### DIFF
--- a/lib/composables/dav.spec.ts
+++ b/lib/composables/dav.spec.ts
@@ -240,4 +240,53 @@ describe('dav composable', () => {
 		await waitRefLoaded(isLoading)
 		expect(abort).toBeCalledTimes(1)
 	})
+
+	it('a superseded (aborted) load does not clear the loading state of the newer load', async () => {
+		// Each getDirectoryContents call stays pending until resolved manually,
+		// and rejects with an AbortError when its signal is aborted — mirroring a
+		// real DAV request that is cancelled on fast navigation.
+		const pending: Array<{ resolve: () => void }> = []
+		const client = {
+			stat: vi.fn((v) => ({ data: { path: v } })),
+			getDirectoryContents: vi.fn((_path, opts) => new Promise((resolve, reject) => {
+				opts.signal?.addEventListener('abort', () => {
+					const error = new Error('aborted')
+					error.name = 'AbortError'
+					reject(error)
+				})
+				pending.push({ resolve: () => resolve({ data: [] }) })
+			})),
+		}
+		nextcloudFiles.getClient.mockImplementationOnce(() => client)
+		nextcloudFiles.resultToNode.mockImplementation((v) => v)
+
+		const view = ref<'files' | 'recent' | 'favorites'>('files')
+		const path = ref('/')
+		const { loadFiles, isLoading } = useDAVFiles(view, path)
+
+		// Load A is in flight
+		loadFiles()
+		await nextTick()
+		expect(pending).toHaveLength(1)
+		expect(isLoading.value).toBe(true)
+
+		// Load B supersedes A: navigating aborts A and starts B loading
+		path.value = '/subdir/'
+		await nextTick()
+		expect(pending).toHaveLength(2)
+
+		// Let A's aborted request reject and run its catch/finally
+		await nextTick()
+		await nextTick()
+
+		// Regression: A's finally must not flip isLoading to false while B is
+		// still loading — otherwise the FilePicker sees isLoading=false with a
+		// null folder and confirms an empty selection ("No nodes selected").
+		expect(isLoading.value).toBe(true)
+
+		// Completing B settles the loading state
+		pending[1].resolve()
+		await waitRefLoaded(isLoading)
+		expect(isLoading.value).toBe(false)
+	})
 })

--- a/lib/composables/dav.ts
+++ b/lib/composables/dav.ts
@@ -12,6 +12,64 @@ import { onMounted, ref, shallowRef, watch } from 'vue'
 import { getFile, getNodes, getRecentNodes } from '../utils/dav.ts'
 
 /**
+ * Track which load of a repeatedly started async operation is the current one.
+ *
+ * The returned closure owns the ONLY state shared between overlapping loads
+ * (the abort controller of the most recently started one). A running load
+ * never touches that state directly — it only holds its own `AbortSignal`,
+ * so a stale invocation cannot accidentally reset shared state that already
+ * belongs to a newer load.
+ */
+function createCurrentLoad() {
+	let controller: AbortController | undefined
+
+	/**
+	 * Whether the load owning `signal` has been superseded by a newer `start()`.
+	 *
+	 * Pure query, no side effects — supersession is the only thing that ever
+	 * aborts a load's signal, so `signal.aborted` is exactly this fact.
+	 *
+	 * @param signal The signal this load received from `start()`
+	 * @return `true` when a newer `start()` has superseded this load
+	 */
+	const isSuperseded = (signal: AbortSignal): boolean => signal.aborted
+
+	return {
+		/**
+		 * Start a new load, aborting a still running previous one.
+		 *
+		 * @return This load's own abort signal. It is aborted exactly when a
+		 *         later `start()` supersedes this load.
+		 */
+		start(): AbortSignal {
+			controller?.abort()
+			controller = new AbortController()
+			return controller.signal
+		},
+
+		isSuperseded,
+
+		/**
+		 * Settle the load that owns `signal`.
+		 *
+		 * While not superseded, `controller` is guaranteed to still be this
+		 * load's own (no later `start()` has run), so it can safely be released.
+		 *
+		 * @param signal The signal this load received from `start()`
+		 * @return `true` if this load is still the current one — only then may
+		 *         the caller reset shared state. `false` if it was superseded.
+		 */
+		complete(signal: AbortSignal): boolean {
+			if (isSuperseded(signal)) {
+				return false
+			}
+			controller = undefined
+			return true
+		},
+	}
+}
+
+/**
  * Handle file loading using WebDAV
  *
  * @param currentView Reference to the current files view
@@ -42,9 +100,11 @@ export function useDAVFiles(
 	const isLoading = ref(true)
 
 	/**
-	 * The cancelable promise used internally to cancel on fast navigation
+	 * Coordination of overlapping loads on fast navigation.
+	 * All shared state lives inside this closure — `loadDAVFiles` itself only
+	 * ever holds the per-invocation signal returned by `currentLoad.start()`.
 	 */
-	let abortController: AbortController | undefined
+	const currentLoad = createCurrentLoad()
 
 	/**
 	 * Create a new directory in the current path
@@ -66,34 +126,38 @@ export function useDAVFiles(
 	 * Force reload files using the DAV client
 	 */
 	async function loadDAVFiles() {
-		if (abortController) {
-			abortController.abort()
-			abortController = undefined
-		}
+		// `signal` is this invocation's own — the only way a newer load can
+		// interact with this one is by aborting it through currentLoad.start().
+		const signal = currentLoad.start()
 
-		abortController = new AbortController()
 		isLoading.value = true
 		try {
 			if (currentView.value === 'favorites') {
-				files.value = await getFavoriteNodes({ client, path: currentPath.value, signal: abortController.signal })
+				files.value = await getFavoriteNodes({ client, path: currentPath.value, signal })
 				folder.value = null
 			} else if (currentView.value === 'recent') {
-				files.value = await getRecentNodes({ client, signal: abortController.signal })
+				files.value = await getRecentNodes({ client, signal })
 				folder.value = null
 			} else {
-				const content = await getNodes({ client, path: currentPath.value, signal: abortController.signal })
+				const content = await getNodes({ client, path: currentPath.value, signal })
 				folder.value = content.folder
 				files.value = content.contents
 			}
 		} catch (error) {
-			if (error instanceof Error && error.name === 'AbortError') {
-				// ignore abort errors
+			// A superseded load's outcome is irrelevant:
+			// only the live load may report errors.
+			if (currentLoad.isSuperseded(signal)) {
 				return
 			}
 			throw error
 		} finally {
-			abortController = undefined
-			isLoading.value = false
+			// Only the still-current load may settle the shared loading state.
+			// A superseded load must never do this — a newer load is still in
+			// flight and `folder` may still be null, which would let the
+			// FilePicker confirm an empty selection ("No nodes selected").
+			if (currentLoad.complete(signal)) {
+				isLoading.value = false
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a race condition that occurs under high load in our CI runners using playwright.

```
Notice:   1 failed
    [chrome] › tests/playwright/e2e/files/live-photos.spec.ts:50:3 › Files: Live photos › 'Show hidden files' is enabled › Copies both files when copying the .mov 
  42 passed (8.0m)

  1) [chrome] › tests/playwright/e2e/files/live-photos.spec.ts:50:3 › Files: Live photos › 'Show hidden files' is enabled › Copies both files when copying the .mov 

    Test timeout of 30000ms exceeded.

    Error: page.waitForResponse: Test ended.

       at ../support/sections/CopyMoveDialogPage.ts:68

      66 |
      67 | 	private async confirm(label: string, method: 'COPY' | 'MOVE'): Promise<void> {
    > 68 | 		const done = this.page.waitForResponse((r) => r.request().method() === method
         | 		                       ^
      69 | 			&& /\/(remote|public)\.php\/dav\/files\//.test(r.url()))
      70 | 		await this.confirmButton(label).click()
      71 | 		await done
        at CopyMoveDialogPage.confirm (/home/runner/actions-runner/_work/server/server/tests/playwright/support/sections/CopyMoveDialogPage.ts:68:26)
        at CopyMoveDialogPage.copyToCurrentFolder (/home/runner/actions-runner/_work/server/server/tests/playwright/support/sections/CopyMoveDialogPage.ts:76:14)
        at /home/runner/actions-runner/_work/server/server/tests/playwright/e2e/files/live-photos.spec.ts:52:25

    Error Context: test-results/files-live-photos-Files-Li-c0514--files-when-copying-the-mov-chrome/error-context.md
```

Here is a summary of the issue that Claude created:

## Root cause (confirmed end-to-end)
A race in `@nextcloud/dialogs`' `useDAVFiles` (`lib/composables/dav.ts`). `loadDAVFiles` aborts the previous load and starts a new one, but the **aborted** load's `finally` block unconditionally ran:
```js
finally {
  abortController = undefined
  isLoading.value = false   // ← clobbers the NEWER load's state
}
```
So when fast navigation supersedes a load, the aborted one flips `isLoading` back to `false` while the **newer** load is still in flight and `folder` is still `null`. In `FilePicker.vue`, the confirm button is only disabled while `isLoading` — so in that window it's **enabled with `currentFolder = null`**, and confirming yields an empty selection → `pickNodes()` throws `FilePickerClosed("No nodes selected")` → `moveOrCopyAction` catches it as "user cancelled" → **no COPY is ever sent** → the test's `waitForResponse` hangs to the timeout. On a fast machine the load wins the race (passes); under load (0.2 CPU / slow CI) the abort wins (fails). That's exactly the `.mov` failure — and why it's intermittent and file-agnostic.

## Fix (branch `fix/race-conditions` in `nextcloud-dialogs`)
`lib/composables/dav.ts` — capture this invocation's controller and only clear shared state if it's still the current load:
```js
finally {
  if (abortController === thisAbortController) {
    abortController = undefined
    isLoading.value = false
  }
}
```
Now a superseded load leaves `isLoading` true until the *real* load finishes, so the FilePicker never confirms with a null folder. Added a regression test in `dav.spec.ts` ("a superseded (aborted) load does not clear the loading state of the newer load").

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
