### PR TITLE
feat: toast timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ There are several options that can be passed in as a second parameter, like the 
 showError('This is an error shown without a timeout', { timeout: -1 })
 ```
 
+Ordinary toasts (success, error, warning, info, and bare messages) use the user-configured toast timeout
+from the theming capabilities (`theming.toastTimeout`) when available, and fall back to
+`TOAST_DEFAULT_TIMEOUT` (7 seconds) otherwise.
+
+Loading toasts stay permanent until hidden manually, and undo toasts keep their fixed undo duration.
+
 A full list of available options can be found in the [documentation](https://nextcloud-libraries.github.io/nextcloud-dialogs/).
 
 ### FilePicker

--- a/README.md
+++ b/README.md
@@ -66,18 +66,9 @@ There are several options that can be passed in as a second parameter, like the 
 showError('This is an error shown without a timeout', { timeout: -1 })
 ```
 
-You can also configure the timeout used by ordinary toasts (success, error, warning, info, and bare messages).
-This is stored on `window`, so separately bundled copies of the library share the same value:
-
-```
-import { setToastTimeout, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
-
-// Keep toasts visible for 30 seconds
-setToastTimeout(30000)
-
-// Or never auto-dismiss ordinary toasts
-setToastTimeout(TOAST_PERMANENT_TIMEOUT)
-```
+Ordinary toasts (success, error, warning, info, and bare messages) use the user-configured toast timeout
+from the theming capabilities (`theming.toastTimeout`) when available, and fall back to
+`TOAST_DEFAULT_TIMEOUT` (7 seconds) otherwise.
 
 Loading toasts stay permanent until hidden manually, and undo toasts keep their fixed undo duration.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ There are several options that can be passed in as a second parameter, like the 
 showError('This is an error shown without a timeout', { timeout: -1 })
 ```
 
+You can also configure the timeout used by ordinary toasts (success, error, warning, info, and bare messages).
+This is stored on `window`, so separately bundled copies of the library share the same value:
+
+```
+import { setToastTimeout, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
+
+// Keep toasts visible for 30 seconds
+setToastTimeout(30000)
+
+// Or never auto-dismiss ordinary toasts
+setToastTimeout(TOAST_PERMANENT_TIMEOUT)
+```
+
+Loading toasts stay permanent until hidden manually, and undo toasts keep their fixed undo duration.
+
 A full list of available options can be found in the [documentation](https://nextcloud-libraries.github.io/nextcloud-dialogs/).
 
 ### FilePicker

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,6 +23,8 @@ export {
 } from './public-auth.ts'
 
 export {
+	getToastTimeout,
+	setToastTimeout,
 	showError,
 	showInfo,
 	showLoading,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,8 +23,6 @@ export {
 } from './public-auth.ts'
 
 export {
-	getToastTimeout,
-	setToastTimeout,
 	showError,
 	showInfo,
 	showLoading,

--- a/lib/toast.spec.ts
+++ b/lib/toast.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { showMessage, TOAST_DEFAULT_TIMEOUT, TOAST_PERMANENT_TIMEOUT, ToastType } from './toast.ts'
+
+const getCapabilities = vi.hoisted(() => vi.fn())
+
+vi.mock('@nextcloud/capabilities', () => ({
+	getCapabilities,
+}))
+
+vi.mock('toastify-js', () => ({
+	default: vi.fn((options: { duration?: number }) => ({
+		options,
+		showToast: vi.fn(),
+		hideToast: vi.fn(),
+	})),
+}))
+
+import Toastify from 'toastify-js'
+
+beforeEach(() => {
+	getCapabilities.mockReset()
+	vi.mocked(Toastify).mockClear()
+})
+
+afterEach(() => {
+	document.body.innerHTML = ''
+})
+
+test('uses default timeout when capabilities are missing', () => {
+	getCapabilities.mockImplementation(() => {
+		throw new Error('no capabilities')
+	})
+
+	showMessage('hello')
+
+	expect(Toastify).toHaveBeenCalledWith(expect.objectContaining({
+		duration: TOAST_DEFAULT_TIMEOUT,
+	}))
+})
+
+test('uses toastTimeout from theming capabilities', () => {
+	getCapabilities.mockReturnValue({
+		theming: {
+			toastTimeout: 15_000,
+		},
+	})
+
+	showMessage('hello')
+
+	expect(Toastify).toHaveBeenCalledWith(expect.objectContaining({
+		duration: 15_000,
+	}))
+})
+
+test('allows permanent timeout from capabilities', () => {
+	getCapabilities.mockReturnValue({
+		theming: {
+			toastTimeout: TOAST_PERMANENT_TIMEOUT,
+		},
+	})
+
+	showMessage('hello')
+
+	expect(Toastify).toHaveBeenCalledWith(expect.objectContaining({
+		duration: TOAST_PERMANENT_TIMEOUT,
+	}))
+})
+
+test('falls back for invalid capability values', () => {
+	getCapabilities.mockReturnValue({
+		theming: {
+			toastTimeout: 0,
+		},
+	})
+
+	showMessage('hello')
+
+	expect(Toastify).toHaveBeenCalledWith(expect.objectContaining({
+		duration: TOAST_DEFAULT_TIMEOUT,
+	}))
+})
+
+test('does not override loading toast duration', () => {
+	getCapabilities.mockReturnValue({
+		theming: {
+			toastTimeout: 30_000,
+		},
+	})
+
+	showMessage('loading', {
+		type: ToastType.LOADING,
+		timeout: TOAST_PERMANENT_TIMEOUT,
+	})
+
+	expect(Toastify).toHaveBeenCalledWith(expect.objectContaining({
+		duration: TOAST_PERMANENT_TIMEOUT,
+	}))
+})

--- a/lib/toast.spec.ts
+++ b/lib/toast.spec.ts
@@ -14,8 +14,17 @@ import {
 	showSuccess,
 	showUndo,
 	showWarning,
+	TOAST_DEFAULT_TIMEOUT,
+	TOAST_PERMANENT_TIMEOUT,
 	ToastAriaLive,
+	ToastType,
 } from './toast.ts'
+
+const getCapabilities = vi.hoisted(() => vi.fn())
+
+vi.mock('@nextcloud/capabilities', () => ({
+	getCapabilities,
+}))
 
 /**
  * Wait for the 50 ms setTimeout used in announce() to fire.
@@ -443,5 +452,93 @@ describe('multiple toasts', () => {
 		const messages = Array.from(document.querySelectorAll('[role="status"]'))
 			.map((el) => el.textContent?.trim())
 		expect(messages).toEqual(['First', 'Second', 'Third'])
+	})
+})
+
+describe('timeout resolution', () => {
+	beforeEach(() => {
+		getCapabilities.mockReset()
+	})
+
+	test('uses default timeout when capabilities are missing', async () => {
+		getCapabilities.mockReturnValue(undefined)
+		showMessage('hello')
+
+		await vi.advanceTimersByTimeAsync(TOAST_DEFAULT_TIMEOUT - 1)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+
+		await vi.advanceTimersByTimeAsync(1)
+		expect(document.querySelector('[role="status"]')).toBeNull()
+	})
+
+	test('uses default timeout when capabilities access throws', async () => {
+		getCapabilities.mockImplementation(() => {
+			throw new Error('window is not defined')
+		})
+		showMessage('hello')
+
+		await vi.advanceTimersByTimeAsync(TOAST_DEFAULT_TIMEOUT - 1)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+
+		await vi.advanceTimersByTimeAsync(1)
+		expect(document.querySelector('[role="status"]')).toBeNull()
+	})
+
+	test('uses toastTimeout from theming capabilities', async () => {
+		getCapabilities.mockReturnValue({
+			theming: {
+				toastTimeout: 15_000,
+			},
+		})
+		showMessage('hello')
+
+		await vi.advanceTimersByTimeAsync(14_999)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+
+		await vi.advanceTimersByTimeAsync(1)
+		expect(document.querySelector('[role="status"]')).toBeNull()
+	})
+
+	test('allows permanent timeout from capabilities', async () => {
+		getCapabilities.mockReturnValue({
+			theming: {
+				toastTimeout: TOAST_PERMANENT_TIMEOUT,
+			},
+		})
+		showMessage('hello')
+
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+	})
+
+	test('falls back for invalid capability values', async () => {
+		getCapabilities.mockReturnValue({
+			theming: {
+				toastTimeout: 0,
+			},
+		})
+		showMessage('hello')
+
+		await vi.advanceTimersByTimeAsync(TOAST_DEFAULT_TIMEOUT - 1)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+
+		await vi.advanceTimersByTimeAsync(1)
+		expect(document.querySelector('[role="status"]')).toBeNull()
+	})
+
+	test('does not override loading toast duration', async () => {
+		getCapabilities.mockReturnValue({
+			theming: {
+				toastTimeout: 30_000,
+			},
+		})
+
+		showMessage('loading', {
+			type: ToastType.LOADING,
+			timeout: TOAST_PERMANENT_TIMEOUT,
+		})
+
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
 	})
 })

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -42,6 +42,48 @@ export const TOAST_DEFAULT_TIMEOUT = 7000
 export const TOAST_PERMANENT_TIMEOUT = -1
 
 /**
+ * Shared browser-global key for the configured toast timeout.
+ * Using `window` ensures separately bundled copies of this package share the same value.
+ */
+const GLOBAL_TOAST_TIMEOUT_KEY = '__nextcloud_dialogs_toast_timeout__'
+
+declare global {
+	interface Window {
+		[GLOBAL_TOAST_TIMEOUT_KEY]?: number
+	}
+}
+
+/**
+ * Get the configured toast timeout in milliseconds.
+ * Falls back to {@link TOAST_DEFAULT_TIMEOUT} when unset.
+ */
+export function getToastTimeout(): number {
+	if (typeof window !== 'undefined') {
+		const timeout = window[GLOBAL_TOAST_TIMEOUT_KEY]
+		if (typeof timeout === 'number' && (timeout === TOAST_PERMANENT_TIMEOUT || timeout > 0)) {
+			return timeout
+		}
+	}
+	return TOAST_DEFAULT_TIMEOUT
+}
+
+/**
+ * Set the toast timeout used by ordinary toast helpers.
+ * Stored on `window` so independently bundled copies of `@nextcloud/dialogs` share it.
+ *
+ * @param timeout Timeout in milliseconds, or {@link TOAST_PERMANENT_TIMEOUT} for never dismiss
+ */
+export function setToastTimeout(timeout: number): void {
+	if (typeof window === 'undefined') {
+		return
+	}
+	if (timeout !== TOAST_PERMANENT_TIMEOUT && !(timeout > 0)) {
+		throw new Error('Toast timeout must be a positive number or TOAST_PERMANENT_TIMEOUT')
+	}
+	window[GLOBAL_TOAST_TIMEOUT_KEY] = timeout
+}
+
+/**
  * Type of a toast
  *
  * @see https://apvarun.github.io/toastify-js/
@@ -104,7 +146,7 @@ export interface ToastOptions {
  */
 export function showMessage(data: string | Node, options?: ToastOptions): Toast {
 	options = {
-		timeout: TOAST_DEFAULT_TIMEOUT,
+		timeout: getToastTimeout(),
 		isHTML: false,
 		type: undefined,
 		// An undefined selector defaults to the body element
@@ -113,6 +155,16 @@ export function showMessage(data: string | Node, options?: ToastOptions): Toast 
 		onClick: undefined,
 		close: true,
 		...options,
+	}
+
+	// Accessibility preference overrides ordinary/app-specific timeouts.
+	// Loading and undo toasts keep their forced durations; permanent stays permanent.
+	if (
+		options.type !== ToastType.LOADING
+		&& options.type !== ToastType.UNDO
+		&& options.timeout !== TOAST_PERMANENT_TIMEOUT
+	) {
+		options.timeout = getToastTimeout()
 	}
 
 	if (typeof data === 'string' && !options.isHTML) {

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import Toastify from 'toastify-js'
 import LoaderSvg from '../styles/loader.svg?raw'
 import { t } from './utils/l10n.js'
@@ -41,46 +42,35 @@ export const TOAST_DEFAULT_TIMEOUT = 7000
 /** Timeout value to show a toast permanently */
 export const TOAST_PERMANENT_TIMEOUT = -1
 
-/**
- * Shared browser-global key for the configured toast timeout.
- * Using `window` ensures separately bundled copies of this package share the same value.
- */
-const GLOBAL_TOAST_TIMEOUT_KEY = '__nextcloud_dialogs_toast_timeout__'
-
-declare global {
-	interface Window {
-		[GLOBAL_TOAST_TIMEOUT_KEY]?: number
+type ThemingCapabilities = {
+	theming?: {
+		toastTimeout?: number
 	}
 }
 
 /**
- * Get the configured toast timeout in milliseconds.
- * Falls back to {@link TOAST_DEFAULT_TIMEOUT} when unset.
+ * Whether a timeout value is valid for ordinary toasts.
+ *
+ * @param timeout Timeout in milliseconds
  */
-export function getToastTimeout(): number {
-	if (typeof window !== 'undefined') {
-		const timeout = window[GLOBAL_TOAST_TIMEOUT_KEY]
-		if (typeof timeout === 'number' && (timeout === TOAST_PERMANENT_TIMEOUT || timeout > 0)) {
+function isValidToastTimeout(timeout: number): boolean {
+	return timeout === TOAST_PERMANENT_TIMEOUT || timeout > 0
+}
+
+/**
+ * Resolve the user-configured toast timeout from theming capabilities.
+ * Falls back to {@link TOAST_DEFAULT_TIMEOUT} when unset or invalid.
+ */
+function getToastTimeout(): number {
+	try {
+		const timeout = (getCapabilities() as ThemingCapabilities)?.theming?.toastTimeout
+		if (typeof timeout === 'number' && isValidToastTimeout(timeout)) {
 			return timeout
 		}
+	} catch {
+		// Capabilities may be unavailable outside the browser (e.g. unit tests).
 	}
 	return TOAST_DEFAULT_TIMEOUT
-}
-
-/**
- * Set the toast timeout used by ordinary toast helpers.
- * Stored on `window` so independently bundled copies of `@nextcloud/dialogs` share it.
- *
- * @param timeout Timeout in milliseconds, or {@link TOAST_PERMANENT_TIMEOUT} for never dismiss
- */
-export function setToastTimeout(timeout: number): void {
-	if (typeof window === 'undefined') {
-		return
-	}
-	if (timeout !== TOAST_PERMANENT_TIMEOUT && !(timeout > 0)) {
-		throw new Error('Toast timeout must be a positive number or TOAST_PERMANENT_TIMEOUT')
-	}
-	window[GLOBAL_TOAST_TIMEOUT_KEY] = timeout
 }
 
 /**

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import { createApp } from 'vue'
 import ToastContainer from './components/ToastContainer.vue'
 import ToastNotification from './components/ToastNotification.vue'
@@ -39,6 +40,37 @@ export const TOAST_UNDO_TIMEOUT = 10000
 export const TOAST_DEFAULT_TIMEOUT = 7000
 /** Timeout value to show a toast permanently */
 export const TOAST_PERMANENT_TIMEOUT = -1
+
+type ThemingCapabilities = {
+	theming?: {
+		toastTimeout?: number
+	}
+}
+
+/**
+ * Whether a timeout value is valid for ordinary toasts.
+ *
+ * @param timeout Timeout in milliseconds
+ */
+function isValidToastTimeout(timeout: number): boolean {
+	return timeout === TOAST_PERMANENT_TIMEOUT || timeout > 0
+}
+
+/**
+ * Resolve the user-configured toast timeout from theming capabilities.
+ * Falls back to {@link TOAST_DEFAULT_TIMEOUT} when unset or invalid.
+ */
+function getToastTimeout(): number {
+	try {
+		const timeout = (getCapabilities() as ThemingCapabilities | undefined)?.theming?.toastTimeout
+		if (typeof timeout === 'number' && isValidToastTimeout(timeout)) {
+			return timeout
+		}
+	} catch (_error) {
+		// Catch any exception from capability access and fallback to default timeout.
+	}
+	return TOAST_DEFAULT_TIMEOUT
+}
 
 export interface ToastOptions {
 	/**
@@ -246,7 +278,7 @@ function getAnnouncementText(data: string | Node, isHTML: boolean): string {
  */
 export function showMessage(data: string | Node, options?: ToastOptions): ToastHandle {
 	const opts = {
-		timeout: TOAST_DEFAULT_TIMEOUT,
+		timeout: getToastTimeout(),
 		isHTML: false,
 		type: undefined as ToastType | undefined,
 		selector: undefined as string | undefined,

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -66,7 +66,7 @@ function getToastTimeout(): number {
 		if (typeof timeout === 'number' && isValidToastTimeout(timeout)) {
 			return timeout
 		}
-	} catch (_error) {
+	} catch {
 		// Catch any exception from capability access and fallback to default timeout.
 	}
 	return TOAST_DEFAULT_TIMEOUT

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/browser-storage": "^0.5.0",
+        "@nextcloud/capabilities": "^1.2.1",
         "@nextcloud/event-bus": "^3.3.3",
         "@nextcloud/files": "^4.0.0",
         "@nextcloud/initial-state": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/browser-storage": "^0.5.0",
+    "@nextcloud/capabilities": "^1.2.1",
     "@nextcloud/event-bus": "^3.3.3",
     "@nextcloud/files": "^4.0.0",
     "@nextcloud/initial-state": "^3.0.0",


### PR DESCRIPTION
## Summary
Adds configurable timeouts for ordinary toast notifications.
- Exposes `getToastTimeout` and `setToastTimeout`
- Shares the configured value across bundled library copies via `window`
- Preserves fixed behavior for loading, undo, and permanent toasts

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
