### PR TITLE
feat(toast): pause auto-dismiss on interaction, reach the stack with F6, respect reduced motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ showError('This is an error shown without a timeout', { timeout: -1 })
 
 A full list of available options can be found in the [documentation](https://nextcloud-libraries.github.io/nextcloud-dialogs/).
 
+#### Accessibility
+
+Toasts are announced in a screen reader through a live region, assertive for errors and undo
+messages and polite for everything else. The announcement is prefixed with the type of the
+toast, so its meaning does not rely on the colour alone. Use the `ariaLive` option to override
+the level, or set it to `ToastAriaLive.OFF` to keep a toast from being announced at all.
+
+A few behaviours are handled by the library and worth knowing about when writing apps:
+
+- Toasts do not time out while the user hovers or keyboard-focuses the notification stack, so a
+  message cannot disappear while it is being read.
+- Pressing <kbd>F6</kbd> moves the focus to the notification stack, which is otherwise at the
+  very end of the document. <kbd>Esc</kbd> moves it back to where it came from, and closing the
+  focused toast hands the focus back as well.
+- The entrance animation is skipped for users who ask for reduced motion.
+
 ### FilePicker
 To spawn the FilePicker provided by the library you have to use the *FilePickerBuilder*.
 The *FilePickerBuilder* is included in the main entry point of this library, so you can use it like this:

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -175,6 +175,9 @@ msgstr ""
 msgid "No matching files"
 msgstr ""
 
+msgid "Notifications ({hotkey})"
+msgstr ""
+
 msgid "Please enter a name with at least 2 characters."
 msgstr ""
 

--- a/lib/components/ToastContainer.vue
+++ b/lib/components/ToastContainer.vue
@@ -34,16 +34,30 @@
 	<!--
 		Visual notification stack.
 		Individual toasts are mounted here by toast.ts via createApp;
-		this component only manages positioning and lifecycle.
+		this component only manages positioning, focus and lifecycle.
+
+		The stack is a labelled region so it can be reached with the
+		TOAST_FOCUS_HOTKEY shortcut and found in the landmark list of a screen
+		reader. Role and label are only exposed while toasts are actually shown,
+		so every page is not left with an empty "Notifications" landmark.
 	-->
 	<div
 		ref="containerRef"
-		:class="[$style.toastContainer, { [$style.toastContainer_navOpen]: navOpen }]" />
+		:class="[$style.toastContainer, { [$style.toastContainer_navOpen]: navOpen }]"
+		data-nc-toast-stack
+		tabindex="-1"
+		:role="hasToasts ? 'region' : undefined"
+		:aria-label="hasToasts ? stackLabel : undefined"
+		@focusin="handleFocusIn"
+		@focusout="handleFocusOut"
+		@keydown.esc="handleEscape" />
 </template>
 
 <script setup lang="ts">
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
+import { t } from '../utils/l10n.js'
+import { TOAST_FOCUS_HOTKEY, TOAST_FOCUS_RELEASE_EVENT } from './toastStack.ts'
 
 /**
  * How long (ms) a live-region item stays in the DOM.
@@ -58,6 +72,24 @@ let _assertiveClearTimer: ReturnType<typeof setTimeout> | null = null
 const politeRef = useTemplateRef('politeRef')
 const assertiveRef = useTemplateRef('assertiveRef')
 const containerRef = useTemplateRef('containerRef')
+
+/** Accessible name of the stack, mentioning the shortcut that reaches it */
+const stackLabel = t('Notifications ({hotkey})', { hotkey: TOAST_FOCUS_HOTKEY })
+
+/**
+ * Whether the stack currently holds at least one toast.
+ * Toasts are mounted by toast.ts as separate Vue apps, so their number is
+ * observed from the DOM rather than tracked in this component's state.
+ */
+const hasToasts = ref(false)
+
+/**
+ * Element that had the focus before it moved into the stack. Kept only while
+ * the stack owns the focus, so it can be handed back when the user leaves the
+ * stack with Escape or when the toast holding the focus is dismissed.
+ */
+let _previousFocus: HTMLElement | null = null
+let _toastObserver: MutationObserver | null = null
 
 /**
  * Tracks whether the Nextcloud app-navigation sidebar is currently open.
@@ -145,6 +177,106 @@ function getContainerEl(): HTMLElement | null {
 	return containerRef.value
 }
 
+/**
+ * Give the focus back to the element the user came from, if it is still around.
+ */
+function returnFocus(): void {
+	const previous = _previousFocus
+	_previousFocus = null
+	if (previous?.isConnected) {
+		previous.focus()
+	}
+}
+
+/**
+ * Move the focus into the stack, remembering where it came from.
+ * Ignored while no toast is shown, so the shortcut keeps its browser default
+ * on pages without notifications.
+ *
+ * @param event The keydown event of the shortcut
+ */
+function handleHotkey(event: KeyboardEvent): void {
+	const el = containerRef.value
+	if (event.key !== TOAST_FOCUS_HOTKEY
+		|| event.altKey || event.ctrlKey || event.metaKey || event.shiftKey
+		|| !el || el.children.length === 0 || el.contains(document.activeElement)) {
+		return
+	}
+
+	event.preventDefault()
+	_previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+	el.focus()
+}
+
+/**
+ * Remember where the focus came from when it enters the stack by other means
+ * than the shortcut, e.g. by tabbing into it.
+ *
+ * @param event The focusin event
+ */
+function handleFocusIn(event: FocusEvent): void {
+	const el = containerRef.value
+	const from = event.relatedTarget
+	if (!el || (from instanceof Node && el.contains(from))) {
+		// Moving between elements inside the stack, the origin is unchanged
+		return
+	}
+
+	_previousFocus = from instanceof HTMLElement ? from : _previousFocus
+}
+
+/**
+ * Forget the remembered origin once the focus really leaves the stack.
+ * A focusout without a new target means the focused element went away, which
+ * is handled by handleFocusRelease – the origin is still needed there.
+ *
+ * @param event The focusout event
+ */
+function handleFocusOut(event: FocusEvent): void {
+	const el = containerRef.value
+	const to = event.relatedTarget
+	if (!el || !(to instanceof Node) || el.contains(to)) {
+		return
+	}
+
+	_previousFocus = null
+}
+
+/**
+ * Leave the stack on Escape, back to where the focus came from.
+ * The event is not propagated further so an app listening for Escape on the
+ * document does not also react to it, e.g. by closing an unrelated dialog.
+ *
+ * @param event The keydown event
+ */
+function handleEscape(event: KeyboardEvent): void {
+	if (!_previousFocus) {
+		return
+	}
+
+	event.stopPropagation()
+	returnFocus()
+}
+
+/**
+ * Take the focus over from a toast that is about to be removed while holding
+ * it: stay in the stack as long as other toasts are left, otherwise hand the
+ * focus back to the element the user came from.
+ */
+function handleFocusRelease(): void {
+	const el = containerRef.value
+	if (!el) {
+		return
+	}
+
+	// The dismissed toast is still part of the stack at this point
+	if (el.children.length > 1) {
+		el.focus()
+	} else {
+		returnFocus()
+	}
+}
+
 onMounted(() => {
 	// Seed the initial state from the DOM in case the navigation-toggled event
 	// was already fired before this component was mounted.
@@ -155,10 +287,28 @@ onMounted(() => {
 	}
 
 	subscribe('navigation-toggled', handleNavigationToggle)
+
+	document.addEventListener('keydown', handleHotkey)
+	containerRef.value?.addEventListener(TOAST_FOCUS_RELEASE_EVENT, handleFocusRelease)
+
+	// Toasts are mounted into the stack from the outside, so the only way to
+	// know whether any is shown is to watch the element's children.
+	if (containerRef.value) {
+		_toastObserver = new MutationObserver(() => {
+			hasToasts.value = (containerRef.value?.children.length ?? 0) > 0
+		})
+		_toastObserver.observe(containerRef.value, { childList: true })
+	}
 })
 
 onUnmounted(() => {
 	unsubscribe('navigation-toggled', handleNavigationToggle)
+
+	document.removeEventListener('keydown', handleHotkey)
+	containerRef.value?.removeEventListener(TOAST_FOCUS_RELEASE_EVENT, handleFocusRelease)
+
+	_toastObserver?.disconnect()
+	_toastObserver = null
 })
 
 defineExpose({ announce, getContainerEl })
@@ -180,6 +330,17 @@ defineExpose({ announce, getContainerEl })
 	padding: calc(var(--default-grid-baseline) * 2);
 	// Smooth transition when the navigation opens / closes
 	transition: left var(--animation-quick, 100ms) ease;
+
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
+	// Make the shortcut visible: the whole stack is outlined when focused
+	&:focus-visible {
+		outline: var(--border-width-input-focused, 2px) solid var(--color-main-text);
+		outline-offset: 2px;
+		border-radius: var(--border-radius-element, var(--border-radius));
+	}
 }
 
 // When the app navigation is visible, shift right to avoid overlap

--- a/lib/components/ToastNotification.vue
+++ b/lib/components/ToastNotification.vue
@@ -4,6 +4,7 @@
 -->
 <template>
 	<div
+		ref="rootRef"
 		:class="[$style.toast, typeClass, { [$style.toast_clickable]: onClick }]"
 		:role="role"
 		@click="onClick?.()">
@@ -51,12 +52,13 @@
 
 <script setup lang="ts">
 import { mdiClose } from '@mdi/js'
-import { computed, onMounted, onUnmounted, ref, useCssModule } from 'vue'
+import { computed, onBeforeUnmount, onMounted, onUnmounted, ref, useCssModule, useTemplateRef } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import { ToastType } from '../toast.ts'
 import { t } from '../utils/l10n.js'
+import { TOAST_FOCUS_RELEASE_EVENT, TOAST_STACK_SELECTOR } from './toastStack.ts'
 
 const props = withDefaults(defineProps<{
 	/** Text or DOM node to display as the toast body */
@@ -88,9 +90,34 @@ const emit = defineEmits<{
 	dismiss: []
 }>()
 
+/**
+ * Minimum time (ms) a toast is shown again after the user stops interacting
+ * with the stack. Without it a toast whose countdown ran out while paused
+ * would vanish the instant the pointer leaves, which reads as a glitch.
+ */
+const MIN_RESUME_TIMEOUT = 1000
+
 /** Mount target for arbitrary DOM Node content */
 const nodeRef = ref<HTMLElement | null>(null)
+const rootRef = useTemplateRef<HTMLElement>('rootRef')
+
+/** Running auto-dismiss timer; `null` while paused or for permanent toasts */
 let _timer: ReturnType<typeof setTimeout> | null = null
+/** Time (ms) left on the countdown, updated every time it is paused */
+let _remaining = 0
+/** `Date.now()` of the moment the countdown was last started */
+let _startedAt = 0
+/**
+ * Element the pause listeners are bound to: the shared stack if this toast is
+ * mounted inside a ToastContainer, otherwise the toast itself.
+ * Listening on the stack means interacting with *any* toast pauses all of
+ * them – a toast must not disappear while the user is reading the one above it.
+ */
+let _pauseTarget: HTMLElement | null = null
+/** Whether the pointer is currently over the stack */
+let _isHovered = false
+/** Whether the focus is currently inside the stack */
+let _isFocused = false
 
 const style = useCssModule()
 
@@ -100,12 +127,102 @@ const isStringMessage = computed(() => typeof props.message === 'string')
 const isLoading = computed(() => props.type === ToastType.LOADING)
 const isUndo = computed(() => props.type === ToastType.UNDO)
 
-/** Remove the toast (clears the auto-dismiss timer and emits dismiss). */
-function dismiss(): void {
+/** Stop the auto-dismiss timer without touching the remaining time. */
+function clearTimer(): void {
 	if (_timer !== null) {
 		clearTimeout(_timer)
 		_timer = null
 	}
+}
+
+/** Start – or resume – the auto-dismiss countdown with the time left on it. */
+function startTimer(): void {
+	if (_timer !== null || _remaining <= 0) {
+		return
+	}
+	_startedAt = Date.now()
+	_timer = setTimeout(dismiss, _remaining)
+}
+
+/** Freeze the auto-dismiss countdown, remembering how much time is left. */
+function pauseTimer(): void {
+	if (_timer === null) {
+		return
+	}
+
+	clearTimer()
+	// Never floor above the timeout the caller asked for, a short-lived toast
+	// must not outlive it just because it was hovered
+	const floor = Math.min(MIN_RESUME_TIMEOUT, props.timeout)
+	_remaining = Math.max(floor, _remaining - (Date.now() - _startedAt))
+}
+
+/**
+ * Hold the countdown while the user is hovering or keyboard-focusing the
+ * stack, and resume it once they are done (WCAG 2.2.1 – Timing Adjustable).
+ */
+function updateTimerState(): void {
+	if (_isHovered || _isFocused) {
+		pauseTimer()
+	} else {
+		startTimer()
+	}
+}
+
+/**
+ * Check whether the pointer or focus only moved between elements *inside* the
+ * stack. `pointerout` / `focusout` bubble, so moving from a toast to its close
+ * button would otherwise be reported as leaving the stack.
+ *
+ * @param event The pointerout or focusout event
+ * @return True when the new target is still part of the stack
+ */
+function movedWithinStack(event: PointerEvent | FocusEvent): boolean {
+	return event.relatedTarget instanceof Node
+		&& (_pauseTarget?.contains(event.relatedTarget) ?? false)
+}
+
+/** Pointer entered the stack: hold the countdown. */
+function handlePointerOver(): void {
+	_isHovered = true
+	updateTimerState()
+}
+
+/**
+ * Pointer left the stack: resume the countdown.
+ *
+ * @param event The pointerout event
+ */
+function handlePointerOut(event: PointerEvent): void {
+	if (movedWithinStack(event)) {
+		return
+	}
+	_isHovered = false
+	updateTimerState()
+}
+
+/** Focus moved into the stack: hold the countdown. */
+function handleFocusIn(): void {
+	_isFocused = true
+	updateTimerState()
+}
+
+/**
+ * Focus left the stack: resume the countdown.
+ *
+ * @param event The focusout event
+ */
+function handleFocusOut(event: FocusEvent): void {
+	if (movedWithinStack(event)) {
+		return
+	}
+	_isFocused = false
+	updateTimerState()
+}
+
+/** Remove the toast (clears the auto-dismiss timer and emits dismiss). */
+function dismiss(): void {
+	clearTimer()
 	emit('dismiss')
 }
 
@@ -127,16 +244,45 @@ onMounted(() => {
 	if (props.message instanceof Node && nodeRef.value) {
 		nodeRef.value.appendChild(props.message)
 	}
-	// Start the auto-dismiss countdown
+
+	_pauseTarget = rootRef.value?.closest<HTMLElement>(TOAST_STACK_SELECTOR) ?? rootRef.value
+	if (_pauseTarget) {
+		_pauseTarget.addEventListener('pointerover', handlePointerOver)
+		_pauseTarget.addEventListener('pointerout', handlePointerOut)
+		_pauseTarget.addEventListener('focusin', handleFocusIn)
+		_pauseTarget.addEventListener('focusout', handleFocusOut)
+
+		// The user may already be interacting with the stack when this toast is
+		// added to it – no pointerover/focusin fires in that case.
+		_isHovered = _pauseTarget.matches(':hover')
+		_isFocused = _pauseTarget.contains(document.activeElement)
+	}
+
+	// Start the auto-dismiss countdown, unless the toast is permanent
 	if (props.timeout > 0) {
-		_timer = setTimeout(dismiss, props.timeout)
+		_remaining = props.timeout
+		updateTimerState()
+	}
+})
+
+onBeforeUnmount(() => {
+	// Still in the DOM here, so we can tell whether this toast holds the focus.
+	// Hand it over to the container before disappearing, otherwise a keyboard
+	// user who just pressed the close button is dropped on <body>.
+	if (rootRef.value?.contains(document.activeElement) && _pauseTarget !== rootRef.value) {
+		_pauseTarget?.dispatchEvent(new CustomEvent(TOAST_FOCUS_RELEASE_EVENT))
 	}
 })
 
 onUnmounted(() => {
-	if (_timer !== null) {
-		clearTimeout(_timer)
-		_timer = null
+	clearTimer()
+
+	if (_pauseTarget) {
+		_pauseTarget.removeEventListener('pointerover', handlePointerOver)
+		_pauseTarget.removeEventListener('pointerout', handlePointerOut)
+		_pauseTarget.removeEventListener('focusin', handleFocusIn)
+		_pauseTarget.removeEventListener('focusout', handleFocusOut)
+		_pauseTarget = null
 	}
 })
 
@@ -170,6 +316,11 @@ $spacing: 12px;
 	min-height: var(--clickable-area-large);
 	pointer-events: auto;
 	animation: toast-in var(--animation-slow) ease-out;
+
+	// Users who asked for less motion get the toast without the slide-in
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 }
 
 // Modifiers

--- a/lib/components/toastStack.ts
+++ b/lib/components/toastStack.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Marker attribute of the visual toast stack rendered by ToastContainer.
+ *
+ * Individual toasts are mounted as separate Vue apps inside that element
+ * (see `_mountToast` in `toast.ts`), so they cannot use provide/inject to talk
+ * to the container. They locate the stack through this attribute instead,
+ * which also works when the container comes from another bundle of this
+ * library sharing the same stack.
+ */
+export const TOAST_STACK_SELECTOR = '[data-nc-toast-stack]'
+
+/**
+ * Event a toast dispatches on the stack when it is dismissed while holding
+ * the focus, asking the container to take the focus over before the toast is
+ * removed from the DOM – otherwise focus would silently fall back to `<body>`.
+ */
+export const TOAST_FOCUS_RELEASE_EVENT = 'nc-toast:focus-release'
+
+/**
+ * Key that moves the focus into the toast stack.
+ *
+ * F6 is the conventional "move to the next pane" key of the WAI-ARIA authoring
+ * practices, which is what a notification stack outside the normal reading
+ * order needs: toasts appear at the very end of the document, so without a
+ * shortcut a keyboard user would have to tab through the whole page to reach
+ * them before they time out.
+ */
+export const TOAST_FOCUS_HOTKEY = 'F6'

--- a/lib/toast.spec.ts
+++ b/lib/toast.spec.ts
@@ -27,6 +27,50 @@ async function waitForAnnouncement() {
 	await vi.advanceTimersByTimeAsync(100)
 }
 
+/** The visual toast stack every toast is mounted into. */
+function getStack(): HTMLElement {
+	return document.querySelector('[data-nc-toast-stack]') as HTMLElement
+}
+
+/**
+ * Let the ToastContainer pick up the current number of toasts.
+ * They are mounted from the outside and counted with a MutationObserver, so
+ * the region attributes only settle after its callback and the next render.
+ */
+async function flushStackObserver() {
+	await vi.advanceTimersByTimeAsync(1)
+	await nextTick()
+}
+
+/**
+ * Move the pointer onto an element of the stack.
+ *
+ * @param target Element the pointer enters
+ */
+function pointerOver(target: Element): void {
+	target.dispatchEvent(new PointerEvent('pointerover', { bubbles: true }))
+}
+
+/**
+ * Move the pointer off an element of the stack.
+ *
+ * @param target Element the pointer leaves
+ * @param to     Element the pointer moves to, `document.body` (outside the stack) by default
+ */
+function pointerOut(target: Element, to: Node = document.body): void {
+	target.dispatchEvent(new PointerEvent('pointerout', { bubbles: true, relatedTarget: to }))
+}
+
+/**
+ * Press a key, by default on the document as the shortcut listener does.
+ *
+ * @param key    The `KeyboardEvent.key` value
+ * @param target Element receiving the event
+ */
+function pressKey(key: string, target: EventTarget = document): void {
+	target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+}
+
 beforeEach(() => {
 	vi.useFakeTimers()
 	// Clear the DOM and the window-global singleton so each test
@@ -427,6 +471,239 @@ describe('navigation-aware positioning', () => {
 		emit('navigation-toggled', { open: false })
 		await nextTick()
 		expect(container.classList.contains('toastContainer_navOpen')).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Auto-dismiss is paused while the user interacts with the stack (WCAG 2.2.1)
+// ---------------------------------------------------------------------------
+
+describe('pausing the auto-dismiss', () => {
+	test('hovering a toast keeps it visible past its timeout', async () => {
+		showMessage('Hovered', { timeout: 1000 })
+		const toast = document.querySelector('[role="status"]') as HTMLElement
+
+		pointerOver(toast)
+		await vi.advanceTimersByTimeAsync(10_000)
+
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+	})
+
+	test('the countdown resumes once the pointer leaves the stack', async () => {
+		showMessage('Hovered', { timeout: 1000 })
+		const toast = document.querySelector('[role="status"]') as HTMLElement
+
+		pointerOver(toast)
+		await vi.advanceTimersByTimeAsync(10_000)
+		pointerOut(toast)
+
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(document.querySelector('[role="status"]')).toBeNull()
+	})
+
+	test('the time already elapsed is not given back on resume', async () => {
+		showMessage('Hovered', { timeout: 5000 })
+		const toast = document.querySelector('[role="status"]') as HTMLElement
+
+		// 1s of the 5s timeout is used up before pausing
+		await vi.advanceTimersByTimeAsync(1000)
+		pointerOver(toast)
+		await vi.advanceTimersByTimeAsync(60_000)
+		pointerOut(toast)
+
+		// The remaining 4s – and not the full timeout – are left
+		await vi.advanceTimersByTimeAsync(3999)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+		await vi.advanceTimersByTimeAsync(1)
+		expect(document.querySelector('[role="status"]')).toBeNull()
+	})
+
+	test('a toast paused past its timeout stays for a moment after resuming', async () => {
+		showMessage('Hovered', { timeout: 1000 })
+		const toast = document.querySelector('[role="status"]') as HTMLElement
+
+		// Only 100 ms would be left, which would be an instant disappearance
+		await vi.advanceTimersByTimeAsync(900)
+		pointerOver(toast)
+		await vi.advanceTimersByTimeAsync(60_000)
+		pointerOut(toast)
+
+		await vi.advanceTimersByTimeAsync(999)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+		await vi.advanceTimersByTimeAsync(1)
+		expect(document.querySelector('[role="status"]')).toBeNull()
+	})
+
+	test('moving the pointer inside the stack does not resume the countdown', async () => {
+		showMessage('Hovered', { timeout: 1000 })
+		const toast = document.querySelector('[role="status"]') as HTMLElement
+		const closeBtn = document.querySelector('button[aria-label="Close"]') as HTMLElement
+
+		pointerOver(toast)
+		// From the toast onto its own close button – still inside the stack
+		pointerOut(toast, closeBtn)
+		await vi.advanceTimersByTimeAsync(10_000)
+
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+	})
+
+	test('hovering one toast pauses the whole stack', async () => {
+		showMessage('First', { timeout: 1000 })
+		showMessage('Second', { timeout: 1000 })
+		const [first] = Array.from(document.querySelectorAll('[role="status"]'))
+
+		// Reading the first toast must not make the second one vanish
+		pointerOver(first)
+		await vi.advanceTimersByTimeAsync(10_000)
+
+		expect(document.querySelectorAll('[role="status"]')).toHaveLength(2)
+	})
+
+	test('a toast added while the stack has focus starts out paused', async () => {
+		showMessage('First', { timeout: 1000 })
+		getStack().focus()
+
+		showMessage('Second', { timeout: 1000 })
+		await vi.advanceTimersByTimeAsync(10_000)
+
+		expect(document.querySelectorAll('[role="status"]')).toHaveLength(2)
+	})
+
+	test('focusing the stack keeps toasts visible past their timeout', async () => {
+		showMessage('Focused', { timeout: 1000 })
+		const closeBtn = document.querySelector('button[aria-label="Close"]') as HTMLElement
+
+		closeBtn.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: document.body }))
+		await vi.advanceTimersByTimeAsync(10_000)
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+
+		closeBtn.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }))
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(document.querySelector('[role="status"]')).toBeNull()
+	})
+
+	test('a permanent toast is unaffected by hovering', async () => {
+		showLoading('Uploading…')
+		const toast = document.querySelector('[role="status"]') as HTMLElement
+
+		pointerOver(toast)
+		pointerOut(toast)
+		await vi.advanceTimersByTimeAsync(100_000)
+
+		expect(document.querySelector('[role="status"]')).not.toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Reaching the toasts with the keyboard
+// ---------------------------------------------------------------------------
+
+describe('keyboard access to the stack', () => {
+	test('the stack is a labelled region mentioning the shortcut while toasts are shown', async () => {
+		showInfo('Reachable')
+		await flushStackObserver()
+
+		const stack = getStack()
+		expect(stack.getAttribute('role')).toBe('region')
+		expect(stack.getAttribute('aria-label')).toBe('Notifications (F6)')
+	})
+
+	test('the empty stack exposes no region so pages keep a clean landmark list', async () => {
+		const handle = showInfo('Temporary')
+		await flushStackObserver()
+		expect(getStack().getAttribute('role')).toBe('region')
+
+		handle.hideToast()
+		await flushStackObserver()
+
+		expect(getStack().getAttribute('role')).toBeNull()
+		expect(getStack().getAttribute('aria-label')).toBeNull()
+	})
+
+	test('the shortcut moves the focus into the stack', async () => {
+		showInfo('Reachable')
+		await flushStackObserver()
+
+		pressKey('F6')
+
+		expect(document.activeElement).toBe(getStack())
+	})
+
+	test('the shortcut is ignored while no toast is shown', async () => {
+		// Mount the container without leaving a toast in it
+		showInfo('Gone').hideToast()
+		await flushStackObserver()
+
+		const outside = document.createElement('button')
+		document.body.appendChild(outside)
+		outside.focus()
+
+		pressKey('F6')
+
+		expect(document.activeElement).toBe(outside)
+	})
+
+	test('the shortcut is ignored when pressed with a modifier', async () => {
+		showInfo('Reachable')
+		await flushStackObserver()
+
+		const outside = document.createElement('button')
+		document.body.appendChild(outside)
+		outside.focus()
+
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F6', ctrlKey: true, bubbles: true }))
+
+		expect(document.activeElement).toBe(outside)
+	})
+
+	test('escape hands the focus back to where it came from', async () => {
+		const outside = document.createElement('button')
+		document.body.appendChild(outside)
+		outside.focus()
+
+		showInfo('Reachable')
+		await flushStackObserver()
+		pressKey('F6')
+		expect(document.activeElement).toBe(getStack())
+
+		pressKey('Escape', getStack())
+
+		expect(document.activeElement).toBe(outside)
+	})
+
+	test('dismissing the focused toast hands the focus back instead of dropping it', async () => {
+		const outside = document.createElement('button')
+		document.body.appendChild(outside)
+		outside.focus()
+
+		showInfo('Closable')
+		await flushStackObserver()
+		pressKey('F6')
+
+		const closeBtn = document.querySelector('button[aria-label="Close"]') as HTMLButtonElement
+		closeBtn.focus()
+		closeBtn.click()
+
+		expect(document.querySelector('[role="status"]')).toBeNull()
+		expect(document.activeElement).toBe(outside)
+	})
+
+	test('dismissing a toast keeps the focus in the stack while others remain', async () => {
+		const outside = document.createElement('button')
+		document.body.appendChild(outside)
+		outside.focus()
+
+		showInfo('First')
+		showInfo('Second')
+		await flushStackObserver()
+		pressKey('F6')
+
+		const closeBtn = document.querySelector('button[aria-label="Close"]') as HTMLButtonElement
+		closeBtn.focus()
+		closeBtn.click()
+
+		expect(document.querySelectorAll('[role="status"]')).toHaveLength(1)
+		expect(document.activeElement).toBe(getStack())
 	})
 })
 


### PR DESCRIPTION
Follow-up to #2324. That PR rewrote the toasts as a self-contained component, and the review ended with [three points](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2324#issuecomment-3389440266) that @skjnldsv preferred to keep out of it and do separately. This is that PR.

The first point — the toast type being conveyed by colour alone — turned out to be [already covered](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2324#issuecomment-3391035816) by the type-prefixed live region announcements (`Error: {message}`), so what is left is the other two, plus the focus handling that the shortcut needs to be usable.

## Auto-dismiss pauses while the stack is being used

The original complaint behind this: a toast could disappear while you were still reading it, with no way to hold it. The countdown now stops while the user hovers or keyboard-focuses the notification stack, and resumes when they are done (WCAG 2.2.1 — Timing Adjustable).

- The time already elapsed is kept, so a 7s toast that is hovered after 5s has 2s left, not 7s.
- Resuming has a small floor (1s, or the toast's own timeout when that is shorter) so a toast whose countdown ran out while paused does not vanish the instant the pointer leaves.
- Interacting with *any* toast pauses the *whole* stack. Otherwise the second toast could disappear while you are reading the first one above it.
- Permanent toasts (`showLoading`, `timeout: -1`) are unaffected.

## <kbd>F6</kbd> moves the focus to the toasts

The stack is rendered at the very end of the document, so a keyboard user would have to tab through the entire page to reach a toast before it times out. It is now a labelled region reachable with <kbd>F6</kbd> — the conventional "move to next pane" key of the ARIA authoring practices, which is also where Radix UI puts its (configurable) toast hotkey.

- The accessible name mentions the shortcut, `Notifications (F6)`, as Radix does.
- <kbd>Esc</kbd> moves the focus back to where it came from. The event is not propagated further, so an app listening for Escape on the document does not also react to it.
- A toast that is dismissed while holding the focus hands it over instead of dropping it on `<body>`: to the stack while other toasts remain, otherwise back to the element the user came from. This works for tabbing in as well, not only for the shortcut.
- `role`/`aria-label` are only exposed while toasts are actually shown, so pages are not left with an empty "Notifications" landmark in the landmark list.

:point_right: **One thing to decide:** Firefox and Chrome use <kbd>F6</kbd> to cycle through their own UI panes, and this shortcut takes it over while a toast is visible. That is why Radix defaults to <kbd>F8</kbd> instead. I went with <kbd>F6</kbd> as discussed, but the key is a single constant in `toastStack.ts` if we would rather not shadow the browser's.

## Reduced motion

The slide-in animation and the container's position transition are skipped under `@media (prefers-reduced-motion: reduce)`.

## Notes on the implementation

Toasts are mounted as separate Vue apps inside the container, so they cannot use provide/inject to talk to it. They find the stack through a `data-nc-toast-stack` attribute and signal the focus handover with a DOM event. Both names, and the hotkey, live in a small shared module with stable string values, so this keeps working when a toast from one bundle of the library is mounted into a stack created by another — the case @susnux [raised](https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2324#issuecomment-3323498456) on the previous PR.

The pause listeners use the bubbling `pointerover`/`pointerout` and `focusin`/`focusout` events rather than `mouseenter`/`mouseleave`, since the container itself is `pointer-events: none` and only the toasts inside it are hit-testable.

## Testing

17 new tests in `lib/toast.spec.ts` (130 total, all green), covering the pause/resume timing arithmetic, stack-wide pausing, a toast added while the stack is already focused, the shortcut and its guards, and each focus-handover path. I verified they fail when the corresponding logic is disabled, so they are not passing by accident. The reduced-motion rules are plain CSS and not covered by a test; I checked they are present in the built `dist/style.css`.

Reviewers: this has not been through a real screen reader yet — I have only verified the semantics and the focus order. Worth a pass with NVDA or Orca before merging.
