### PR TITLE
feat: cutomize file picker icon size

### DIFF
--- a/lib/components/FilePicker/FileList.scss
+++ b/lib/components/FilePicker/FileList.scss
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 tr.file-picker__row {
-	height: var(--row-height, 50px);
+	// 18px vertical padding around the preview (50px at the default 32px icon size)
+	height: var(--row-height, calc(var(--file-picker-preview-size, 32px) + 18px));
 
 	td {
 		cursor: pointer;

--- a/lib/components/FilePicker/FileList.vue
+++ b/lib/components/FilePicker/FileList.vue
@@ -258,8 +258,8 @@ const fileContainer = ref<HTMLDivElement>()
 <style scoped lang="scss">
 .file-picker {
 	&__header-preview {
-		width: 22px; // 32px - 16px padding of button + 6px padding in file list rows
-		height: 32px;
+		width: var(--file-picker-preview-size, 32px);
+		height: var(--file-picker-preview-size, 32px);
 		flex: 0 0 auto; // do not shrink or grow
 	}
 
@@ -308,7 +308,7 @@ const fileContainer = ref<HTMLDivElement>()
 				flex-direction: row-reverse;
 			}
 			:deep(.button-vue) {
-				padding-inline: 16px 4px;
+				padding-inline: 4px;
 			}
 		}
 		th.row-size :deep(.button-vue__wrapper) {

--- a/lib/components/FilePicker/FileListIcon.module.scss
+++ b/lib/components/FilePicker/FileListIcon.module.scss
@@ -5,28 +5,46 @@
 /**
  * Icon styling of the file list row preview or fallback icon
  * (leading icon on the name row and header)
+ *
+ * Thumbnail size can be overridden instance-wide via CSS:
+ *   :root { --file-picker-preview-size: 64px; }
  */
 .file-picker__file-icon {
 	position: relative;
-	width: 32px;
-	height: 32px;
-	min-width: 32px;
-	min-height: 32px;
+	width: var(--file-picker-preview-size, 32px);
+	height: var(--file-picker-preview-size, 32px);
+	min-width: var(--file-picker-preview-size, 32px);
+	min-height: var(--file-picker-preview-size, 32px);
 	background-repeat: no-repeat;
 	background-size: contain;
 	border-radius: var(--border-radius-small);
 	// for the fallback
 	display: flex;
 	justify-content: center;
+
+	:global(.material-design-icon),
+	:global(.material-design-icon svg) {
+		width: var(--file-picker-preview-size, 32px);
+		height: var(--file-picker-preview-size, 32px);
+	}
+
+	.file-picker__file-icon-overlay {
+		color: var(--color-primary-element-text);
+		position: absolute;
+		// Center overlay on folder icon with slight offset to match material design folder glyph
+		// ((preview - overlay) / 2) + 2px where overlay is half the preview size
+		inset-block-start: calc(var(--file-picker-preview-size, 32px) * 0.25 + 2px);
+
+		// Overlay is half the preview size (beats NcIconSvgWrapper scoped svg rules)
+		&:global(.icon-vue) :global(svg) {
+			width: calc(var(--file-picker-preview-size, 32px) / 2);
+			height: calc(var(--file-picker-preview-size, 32px) / 2);
+			max-width: calc(var(--file-picker-preview-size, 32px) / 2);
+			max-height: calc(var(--file-picker-preview-size, 32px) / 2);
+		}
+	}
 }
 
 .file-picker__file-icon--primary {
 	color: var(--color-primary-element);
-}
-
-.file-picker__file-icon-overlay {
-	color: var(--color-primary-element-text);
-	position: absolute;
-	// 32px icon size - 16px overlay size + 2px padding to align with folder icon
-	inset-block-start: 10px;
 }

--- a/lib/components/FilePicker/FilePreview.vue
+++ b/lib/components/FilePicker/FilePreview.vue
@@ -7,17 +7,15 @@
 		:style="previewLoaded ? { backgroundImage: `url(${previewURL})` } : undefined"
 		:class="fileListIconStyles['file-picker__file-icon']">
 		<template v-if="!previewLoaded">
-			<IconFile v-if="isFile" :size="32" />
+			<IconFile v-if="isFile" />
 			<template v-else>
 				<NcIconSvgWrapper
 					v-if="folderDecorationIcon"
 					:class="fileListIconStyles['file-picker__file-icon-overlay']"
 					inline
 					:path="folderDecorationIcon"
-					:size="16" />
-				<IconFolder
-					:class="fileListIconStyles['file-picker__file-icon--primary']"
-					:size="32" />
+					size="auto" />
+				<IconFolder :class="fileListIconStyles['file-picker__file-icon--primary']" />
 			</template>
 		</template>
 	</div>

--- a/lib/composables/preview.spec.ts
+++ b/lib/composables/preview.spec.ts
@@ -90,8 +90,10 @@ describe('preview composable', () => {
 		it('supports options', () => {
 			const previewNode = new File(createData('text.txt', 'text/plain'))
 
-			expect(getPreviewURL(previewNode, { size: 16 })?.searchParams.get('x')).toBe('16')
-			expect(getPreviewURL(previewNode, { size: 16 })?.searchParams.get('y')).toBe('16')
+			// Request sizes are snapped to backend-pregenerated 64 / 256
+			expect(getPreviewURL(previewNode, { size: 16 })?.searchParams.get('x')).toBe('64')
+			expect(getPreviewURL(previewNode, { size: 16 })?.searchParams.get('y')).toBe('64')
+			expect(getPreviewURL(previewNode, { size: 65 })?.searchParams.get('x')).toBe('256')
 
 			expect(getPreviewURL(previewNode, { mimeFallback: false })?.searchParams.get('mimeFallback')).toBe('false')
 		})

--- a/lib/composables/preview.ts
+++ b/lib/composables/preview.ts
@@ -13,9 +13,10 @@ import { preloadImage } from '../utils/imagePreload.ts'
 
 interface PreviewOptions {
 	/**
-	 * Size of the previews in px
+	 * Size of the previews in px.
+	 * Snapped to backend-pregenerated sizes (64 or 256); display size is controlled via CSS.
 	 *
-	 * @default 32
+	 * @default from `--file-picker-preview-size` (≤64 → 64, >64 → 256)
 	 */
 	size?: number
 	/**
@@ -39,7 +40,13 @@ interface PreviewOptions {
  * @param options Preview options
  */
 export function getPreviewURL(node: INode, options: PreviewOptions = {}) {
-	options = { size: 32, cropPreview: false, mimeFallback: true, ...options }
+	options = {
+		cropPreview: false,
+		mimeFallback: true,
+		...options,
+		// Only request pregenerated sizes so large folders do not flood the preview generator
+		size: toPregeneratedPreviewSize(options.size ?? getFilePickerPreviewRequestSize()),
+	}
 
 	try {
 		const previewUrl = node.attributes?.previewUrl
@@ -92,4 +99,52 @@ export function usePreviewURL(node: MaybeRef<INode>, options?: MaybeRef<PreviewO
 		previewURL,
 		previewLoaded,
 	}
+}
+
+/**
+ * CSS custom property controlling FilePicker thumbnail *display* size.
+ * Override on `:root` (e.g. via instance theming) to change size without a public API.
+ */
+const FILE_PICKER_PREVIEW_SIZE_VAR = '--file-picker-preview-size'
+
+/** Backend-pregenerated preview sizes (cheap to serve). */
+const PREGENERATED_PREVIEW_SIZE_SMALL = 64
+const PREGENERATED_PREVIEW_SIZE_LARGE = 256
+
+/**
+ * Cached snapped preview *request* size (64 or 256).
+ * CSS is read once — display size does not change at runtime.
+ */
+let previewRequestSize: number | undefined
+
+/**
+ * Map a display size to a backend-pregenerated request size.
+ * size ≤ 64 → 64, size > 64 → 256 (avoids generating arbitrary preview sizes).
+ *
+ * @param size - Desired display or request size in px
+ */
+function toPregeneratedPreviewSize(size: number): number {
+	return size <= PREGENERATED_PREVIEW_SIZE_SMALL
+		? PREGENERATED_PREVIEW_SIZE_SMALL
+		: PREGENERATED_PREVIEW_SIZE_LARGE
+}
+
+/**
+ * Resolve the preview request size from CSS display size (once), snapped to 64 or 256.
+ */
+function getFilePickerPreviewRequestSize(): number {
+	if (previewRequestSize !== undefined) {
+		return previewRequestSize
+	}
+
+	const raw = getComputedStyle(document.documentElement)
+		.getPropertyValue(FILE_PICKER_PREVIEW_SIZE_VAR)
+		.trim()
+	const parsed = Number.parseFloat(raw)
+	const displaySize = Number.isFinite(parsed) && parsed > 0
+		? Math.round(parsed)
+		: PREGENERATED_PREVIEW_SIZE_SMALL
+
+	previewRequestSize = toPregeneratedPreviewSize(displaySize)
+	return previewRequestSize
 }


### PR DESCRIPTION
Fixes: https://github.com/nextcloud-gmbh/customer-feature-requests/issues/1876

## Summary
Make the FilePicker list thumbnails configurable via the CSS custom property `--file-picker-preview-size` (default: `32px`), so instances can change size through theming without a public API.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
